### PR TITLE
Added OpenLibrary books scraper with CSV output

### DIFF
--- a/openlibrary_books.py
+++ b/openlibrary_books.py
@@ -15,7 +15,7 @@ API_SEARCH_URL = "https://openlibrary.org/search.json"
 OUTPUT_CSV = "output/openlibrary_books.csv"
 USER_AGENT = "OpenLibraryScraper/1.0 (+your_email@example.com)"
 CRAWL_DELAY = 1  # seconds
-MAX_PAGES = 5   # Number of pages to fetch (100 results per page)
+MAX_PAGES = 50   # Number of pages to fetch 
 
 
 def fetch_books(page=1):

--- a/output/openlibrary_books.csv
+++ b/output/openlibrary_books.csv
@@ -448,6 +448,7 @@ Sense and Sensibility,Jane Austen,N/A,1811,https://openlibrary.org/works/OL66562
 A Tale of Two Cities,Charles Dickens,N/A,1800,https://openlibrary.org/works/OL8193465W
 Principles of Anatomy and Physiology,"Gerard J. Tortora, Bryan H. Derrickson, Brendan Burkett, Danielle Dye, Julie Cooke, HOUGHTON MIFFLIN HARCOURT, Gregory Peoples, Tara Diversi, Mark McKean, Latika Samalia, Rebecca Mellifont, Richard G. Smith undifferentiated, Gerald J. Tortura, Sandra R. Grabowski, Tortora, Sandra Reynolds Grabowski",N/A,1975,https://openlibrary.org/works/OL1827306W
 2001,Arthur C. Clarke,N/A,1968,https://openlibrary.org/works/OL17365W
+Lilith,George MacDonald,N/A,1895,https://openlibrary.org/works/OL15437W
 Lady Susan,Jane Austen,N/A,1925,https://openlibrary.org/works/OL66614W
 Nineteen Eighty-Four,George Orwell,N/A,1949,https://openlibrary.org/works/OL1168083W
 Tractatus logico-philosophicus,Ludwig Wittgenstein,N/A,1921,https://openlibrary.org/works/OL1410381W
@@ -499,3 +500,4202 @@ A Connecticut Yankee in King Arthur's Court,Mark Twain,N/A,1889,https://openlibr
 A Study in Scarlet,Arthur Conan Doyle,N/A,1887,https://openlibrary.org/works/OL262496W
 "Villette, a novel",Charlotte Brontë,N/A,1853,https://openlibrary.org/works/OL1095403W
 Summa Theologica,"Thomas Aquinas, Kennedy, Daniel Joseph, 1862-1930",N/A,1467,https://openlibrary.org/works/OL15314568W
+Little men,"Louisa May Alcott, Reed",N/A,1885,https://openlibrary.org/works/OL17761452W
+Five Children and It,Edith Nesbit,N/A,1905,https://openlibrary.org/works/OL99499W
+Доктор Живаго,Boris Leonidovich Pasternak,N/A,1957,https://openlibrary.org/works/OL258301W
+A Room of One's Own,Virginia Woolf,N/A,1929,https://openlibrary.org/works/OL39379W
+Animal Farm,George Orwell,N/A,1945,https://openlibrary.org/works/OL1168007W
+To Kill a Mockingbird,Harper Lee,N/A,1960,https://openlibrary.org/works/OL3140822W
+Shirley,Charlotte Brontë,N/A,1800,https://openlibrary.org/works/OL1095397W
+Phantastes,George MacDonald,N/A,1850,https://openlibrary.org/works/OL15450W
+Pippi Långstrump,Astrid Lindgren,N/A,1945,https://openlibrary.org/works/OL14872925W
+They Do It with Mirrors,Agatha Christie,N/A,1952,https://openlibrary.org/works/OL471871W
+And Then There Were None,Agatha Christie,N/A,1939,https://openlibrary.org/works/OL471565W
+The guide of the perplexed of Maimonides,Moses Maimonides,N/A,1473,https://openlibrary.org/works/OL158224W
+Medea,Euripides,N/A,1703,https://openlibrary.org/works/OL66501W
+Catch-22,Joseph Heller,N/A,1961,https://openlibrary.org/works/OL276798W
+A Princess of Mars,Edgar Rice Burroughs,N/A,1917,https://openlibrary.org/works/OL1418187W
+Middlemarch,George Eliot,N/A,1871,https://openlibrary.org/works/OL20867W
+White Fang,Jack London,N/A,1905,https://openlibrary.org/works/OL74504W
+Charlotte's Web,E. B. White,N/A,1952,https://openlibrary.org/works/OL483391W
+Curtain,Agatha Christie,N/A,1975,https://openlibrary.org/works/OL472470W
+50 Fifty Shades of Grey,E. L. James,N/A,2000,https://openlibrary.org/works/OL16336633W
+Autobiography of a Yogi,Yogananda Paramahansa,N/A,1946,https://openlibrary.org/works/OL528094W
+Der Steppenwolf,Hermann Hesse,N/A,1927,https://openlibrary.org/works/OL872773W
+Anne's House of Dreams,Lucy Maud Montgomery,N/A,1917,https://openlibrary.org/works/OL77764W
+King Solomon's Mines,H. Rider Haggard,N/A,1880,https://openlibrary.org/works/OL17448W
+An American Tragedy,Theodore Dreiser,N/A,1900,https://openlibrary.org/works/OL100239W
+Bridge to Terabithia,Katherine Paterson,N/A,1972,https://openlibrary.org/works/OL27079W
+Man and Superman,George Bernard Shaw,N/A,1903,https://openlibrary.org/works/OL1066526W
+Also sprach Zarathustra,Friedrich Nietzsche,N/A,1883,https://openlibrary.org/works/OL98130W
+Principles of Political Economy,John Stuart Mill,N/A,1848,https://openlibrary.org/works/OL1068184W
+Our Mutual Friend,"Charles Dickens, Margeret Tarner, Adam Leverton",N/A,1800,https://openlibrary.org/works/OL13162727W
+La sombra del viento,Carlos Ruiz Zafón,N/A,2001,https://openlibrary.org/works/OL278437W
+Les Liaisons dangereuses,Pierre Choderlos de Laclos,N/A,1782,https://openlibrary.org/works/OL1157252W
+Преступление и наказание,Фёдор Михайлович Достоевский,N/A,1866,https://openlibrary.org/works/OL166894W
+Madame Bovary,Gustave Flaubert,N/A,1856,https://openlibrary.org/works/OL893707W
+Tik-Tok of Oz,L. Frank Baum,N/A,1914,https://openlibrary.org/works/OL18414W
+Ethan Frome,Edith Wharton,N/A,1910,https://openlibrary.org/works/OL98501W
+Salomé,Oscar Wilde,N/A,1893,https://openlibrary.org/works/OL14877882W
+Five Little Pigs,Agatha Christie,N/A,1942,https://openlibrary.org/works/OL471666W
+A  child's garden of verses,Robert Louis Stevenson,N/A,1885,https://openlibrary.org/works/OL24165W
+Angela's Ashes,Frank McCourt,N/A,1709,https://openlibrary.org/works/OL27634W
+Amerika,"Franz Kafka, Ritchie Robertson",N/A,1927,https://openlibrary.org/works/OL498411W
+Homage to Catalonia,George Orwell,N/A,1938,https://openlibrary.org/works/OL1168169W
+A Mind That Found Itself,Clifford Whittingham Beers,N/A,1908,https://openlibrary.org/works/OL6322288W
+Just So Stories,Rudyard Kipling,N/A,1922,https://openlibrary.org/works/OL19899W
+A Game of Thrones,George R. R. Martin,N/A,1996,https://openlibrary.org/works/OL257943W
+How to Win Friends and Influence People,Dale Carnegie,N/A,1936,https://openlibrary.org/works/OL1063267W
+"One, Two, Buckle My Shoe",Agatha Christie,N/A,1940,https://openlibrary.org/works/OL471702W
+Hercule Poirot's Christmas,Agatha Christie,N/A,1939,https://openlibrary.org/works/OL471841W
+Elephants Can Remember,Agatha Christie,N/A,1969,https://openlibrary.org/works/OL471776W
+Siddhartha,Hermann Hesse,N/A,1922,https://openlibrary.org/works/OL872932W
+Terre des hommes,Antoine de Saint-Exupéry,N/A,1936,https://openlibrary.org/works/OL86701W
+Angels & Demons,Dan Brown,N/A,2000,https://openlibrary.org/works/OL76833W
+Ivanhoe,Sir Walter Scott,N/A,1800,https://openlibrary.org/works/OL863808W
+Coloring Book,Donald Nguyen,N/A,2019,https://openlibrary.org/works/OL30432218W
+Orlando,"Virginia Woolf, Carmen Maria Machado",N/A,1928,https://openlibrary.org/works/OL39360W
+Watership Down,Richard Adams,N/A,1972,https://openlibrary.org/works/OL2096536W
+Goodnight Moon,Margaret Wise Brown,N/A,1947,https://openlibrary.org/works/OL151798W
+Martin Eden,Jack London,N/A,1908,https://openlibrary.org/works/OL144822W
+Pygmalion,George Bernard Shaw,N/A,1912,https://openlibrary.org/works/OL1066524W
+Guess How Much I Love You,"Sam McBratney, Anita Jeram",N/A,1994,https://openlibrary.org/works/OL58402W
+Anne of Avonlea,Lucy Maud Montgomery,N/A,1909,https://openlibrary.org/works/OL77744W
+Emily of New Moon,Lucy Maud Montgomery,N/A,1923,https://openlibrary.org/works/OL77781W
+Brave New World,Aldous Huxley,N/A,1932,https://openlibrary.org/works/OL64365W
+Anne of Windy Poplars,Lucy Maud Montgomery,N/A,1900,https://openlibrary.org/works/OL77751W
+Cyrano de Bergerac,Edmond Rostand,N/A,1821,https://openlibrary.org/works/OL551668W
+La père Goriot,Honoré de Balzac,N/A,1800,https://openlibrary.org/works/OL85047W
+It Can't Happen Here,Sinclair Lewis,N/A,1935,https://openlibrary.org/works/OL51145W
+Murder in Mesopotamia,Agatha Christie,N/A,1936,https://openlibrary.org/works/OL472572W
+Sult,Knut Hamsun,N/A,1890,https://openlibrary.org/works/OL573193W
+Cien años de soledad,Gabriel García Márquez,N/A,1967,https://openlibrary.org/works/OL274505W
+A Murder Is Announced,Agatha Christie,N/A,1950,https://openlibrary.org/works/OL471771W
+Veinte poemas de amor y una canción desesperada,Pablo Neruda,N/A,1924,https://openlibrary.org/works/OL979517W
+Sleeping Murder,Agatha Christie,N/A,1940,https://openlibrary.org/works/OL472250W
+Rayuela,Julio Cortázar,N/A,1963,https://openlibrary.org/works/OL14860424W
+Du côté de chez Swann,Marcel Proust,N/A,1908,https://openlibrary.org/works/OL30053009W
+Sonnenfinsternis,Arthur Koestler,N/A,1940,https://openlibrary.org/works/OL804246W
+Vom Kriege,"Carl von Clausewitz, F. N. Maude, James John Graham",N/A,1835,https://openlibrary.org/works/OL62744W
+Lord Edgware Dies,Agatha Christie,N/A,1933,https://openlibrary.org/works/OL471767W
+Murder in Three Acts,Agatha Christie,N/A,1934,https://openlibrary.org/works/OL471765W
+Lord Jim,Joseph Conrad,N/A,1900,https://openlibrary.org/works/OL38684W
+Ender's Game,Orson Scott Card,N/A,1985,https://openlibrary.org/works/OL49488W
+Sparkling Cyanide,Agatha Christie,N/A,1945,https://openlibrary.org/works/OL471983W
+Rebecca,Daphne du Maurier,N/A,1938,https://openlibrary.org/works/OL36633W
+Of Mice and Men,John Steinbeck,N/A,1937,https://openlibrary.org/works/OL23204W
+The Stones of Venice,John Ruskin,N/A,1851,https://openlibrary.org/works/OL88640W
+East of Eden,John Steinbeck,N/A,1952,https://openlibrary.org/works/OL23166W
+In Cold Blood,Truman Capote,N/A,1965,https://openlibrary.org/works/OL1992198W
+Breakfast at Tiffany's,Truman Capote,N/A,1956,https://openlibrary.org/works/OL1992167W
+A Room with a View,E. M. Forster,N/A,1905,https://openlibrary.org/works/OL88813W
+"Laws, etc",United States,N/A,1789,https://openlibrary.org/works/OL10396878W
+Carrie,Stephen King,N/A,1974,https://openlibrary.org/works/OL81626W
+"Tom Sawyer, Detective",Mark Twain,N/A,1897,https://openlibrary.org/works/OL54147W
+Number the Stars,Lois Lowry,N/A,1901,https://openlibrary.org/works/OL1846074W
+Tuesdays with Morrie,Mitch Albom,N/A,1994,https://openlibrary.org/works/OL1822313W
+Tax administration,United States. General Accounting Office,N/A,1986,https://openlibrary.org/works/OL565231W
+George's Marvelous Medicine,Roald Dahl,N/A,1981,https://openlibrary.org/works/OL45866W
+Howards End,E. M. Forster,N/A,1910,https://openlibrary.org/works/OL88881W
+Pedro Páramo,Juan Rulfo,N/A,1955,https://openlibrary.org/works/OL1731119W
+"[William Wheeler Hubbell, authorized to apply for patents.]",United States. Congress. Senate. Committee on Patents,N/A,1858,https://openlibrary.org/works/OL7574091W
+Cato,"Joseph Addison, Christine Dunn Henderson, Mark E. Yellin",N/A,1713,https://openlibrary.org/works/OL1172803W
+Diary,Samuel Pepys,N/A,1825,https://openlibrary.org/works/OL193961W
+The Mammoth Hunters,Jean M. Auel,N/A,1611,https://openlibrary.org/works/OL2746372W
+The Clocks,Agatha Christie,N/A,1963,https://openlibrary.org/works/OL471670W
+The Green Mile,Stephen King,N/A,1996,https://openlibrary.org/works/OL81629W
+Nemesis,Agatha Christie,N/A,1970,https://openlibrary.org/works/OL472594W
+The Colour of Magic,Terry Pratchett,N/A,1983,https://openlibrary.org/works/OL453657W
+"Mary Shelley's Frankenstein; or, the Modern Prometheus (1818 text)",Mary Shelley,N/A,1818,https://openlibrary.org/works/OL25595002W
+The Law of Success,Napoleon Hill,N/A,1969,https://openlibrary.org/works/OL527383W
+Unicorn Coloring Book,kids M. shop notebook,N/A,2019,https://openlibrary.org/works/OL30297379W
+Little House on the Prairie,"Laura Ingalls Wilder, Garth Williams",N/A,1935,https://openlibrary.org/works/OL1719792W
+Financial Management,United States. General Accounting Office,N/A,1987,https://openlibrary.org/works/OL565227W
+The House of the Dead,Фёдор Михайлович Достоевский,N/A,1881,https://openlibrary.org/works/OL166970W
+Diary of a Wimpy Kid,Jeff Kinney,N/A,2002,https://openlibrary.org/works/OL8483260W
+Gitanjali (song offerings),"Rabindranath Tagore, Marie Luise Gothein, William Butler Yeats",N/A,1910,https://openlibrary.org/works/OL308575W
+American notes,"Charles Dickens, Diana C. Archibald, Charles Dickens",N/A,1800,https://openlibrary.org/works/OL8300173W
+The Restaurant at the End of the Universe,Douglas Adams,N/A,1980,https://openlibrary.org/works/OL2163655W
+The Innocence of Father Brown (Father Brown Mystery),"Gilbert Keith Chesterton, Judith Boss, David Widger",N/A,1583,https://openlibrary.org/works/OL76341W
+Lun yu,Confucius,N/A,1750,https://openlibrary.org/works/OL15335450W
+Rembrandt,"Rembrandt Harmenszoon van Rijn, Holm Bevers, Rembrandt, Gary Schwartz, Ludwig Munz, Bob Haak, Christopher Brown",N/A,1900,https://openlibrary.org/works/OL54653W
+The works of Washington Irving,Washington Irving,N/A,1800,https://openlibrary.org/works/OL63910W
+The Sea-Wolf,Jack London,N/A,1900,https://openlibrary.org/works/OL144824W
+The Napoleon of Notting Hill,"Gilbert Keith Chesterton, Madeline Ashby, Catholic Way Publishing Staff",N/A,1904,https://openlibrary.org/works/OL76473W
+The Power of Positive Thinking,Norman Vincent Peale,N/A,1952,https://openlibrary.org/works/OL2917168W
+Foundation,Isaac Asimov,N/A,1951,https://openlibrary.org/works/OL46125W
+"I, Robot",Isaac Asimov,N/A,1950,https://openlibrary.org/works/OL46241W
+The Maltese Falcon,Dashiell Hammett,N/A,1929,https://openlibrary.org/works/OL47266W
+The World Set Free,"H. G. Wells, Ellen Marriage",N/A,1914,https://openlibrary.org/works/OL52257W
+Poems,William Blake,N/A,1783,https://openlibrary.org/works/OL575443W
+Oresteia,Aeschylus,N/A,1845,https://openlibrary.org/works/OL10328829W
+The Screwtape Letters,C.S. Lewis,N/A,1942,https://openlibrary.org/works/OL71072W
+A Wonder Book for Girls and Boys,Nathaniel Hawthorne,N/A,1851,https://openlibrary.org/works/OL455667W
+Exercitia spiritualia,"Saint Ignatius of Loyola, Aloysio R.P Bellecio, Ignatius., William, S.J. Reiser",N/A,1548,https://openlibrary.org/works/OL1238284W
+The Clan of the Cave Bear,Jean M. Auel,N/A,1900,https://openlibrary.org/works/OL2746369W
+Bonjour tristesse,Françoise Sagan,N/A,1954,https://openlibrary.org/works/OL584333W
+Meghadūta,Kālidāsa,N/A,1813,https://openlibrary.org/works/OL293343W
+Ordeal by Innocence,Agatha Christie,N/A,1958,https://openlibrary.org/works/OL472145W
+Cannery Row,John Steinbeck,N/A,1945,https://openlibrary.org/works/OL23199W
+De la démocratie en Amérique,"Alexis de Tocqueville, Gustave de Beaumont",N/A,1835,https://openlibrary.org/works/OL278001W
+Jamaica Inn,Daphne du Maurier,N/A,1936,https://openlibrary.org/works/OL36632W
+Jo's Boys,"Louisa May Alcott, Success Oceo",N/A,1886,https://openlibrary.org/works/OL26668762W
+The Blind Assassin,Margaret Atwood,N/A,2000,https://openlibrary.org/works/OL675698W
+The Woodlanders,Thomas Hardy,N/A,1800,https://openlibrary.org/works/OL44990W
+Le Deuxième Sexe,Simone de Beauvoir,N/A,1949,https://openlibrary.org/works/OL767941W
+Artemis Fowl,Eoin Colfer,N/A,1999,https://openlibrary.org/works/OL5725956W
+The Book of the Dead,"E. A. Wallis Budge, David Lorimer, Foy Scalf, Paul Mirecki",N/A,1894,https://openlibrary.org/works/OL7973699W
+Georg Baselitz,"Georg Baselitz, Rainer M. Mason, Jeremy Lewison, Detlev Gretenkort, Michael Auping, Goerg Simmel, Richard Shiff, Andreas Franzke, Edward Quinn",N/A,1970,https://openlibrary.org/works/OL5144330W
+Leonardo,"Leonardo da Vinci, Kunster, Erfinder, Wissenschaftler, Michael Desmond, Carlo Pedretti",N/A,1946,https://openlibrary.org/works/OL695408W
+Death Comes for the Archbishop,"Willa Cather, Willa Cather",N/A,1926,https://openlibrary.org/works/OL12832W
+Doctor Faustus,Christopher Marlowe,N/A,1662,https://openlibrary.org/works/OL45757W
+The Cat in the Hat,"Dr. Seuss, Simon Mugford",N/A,1957,https://openlibrary.org/works/OL1898309W
+The House at Pooh Corner,A. A. Milne,N/A,1925,https://openlibrary.org/works/OL476471W
+It,Stephen King,N/A,1986,https://openlibrary.org/works/OL81613W
+Van Gogh,Federico Zeri,N/A,1937,https://openlibrary.org/works/OL518261W
+The Dead Zone,Stephen King,N/A,1979,https://openlibrary.org/works/OL81630W
+Mockingjay,Suzanne Collins,N/A,2010,https://openlibrary.org/works/OL14908941W
+The Moon is Down,John Steinbeck,N/A,1942,https://openlibrary.org/works/OL23200W
+Expedition Kon-Tiki,Thor Heyerdahl,N/A,1949,https://openlibrary.org/works/OL2292673W
+The Valley of Horses,Jean M. Auel,N/A,1899,https://openlibrary.org/works/OL2746368W
+The Boxcar Children,Gertrude Chandler Warner,N/A,1924,https://openlibrary.org/works/OL24656586W
+Coraline,Neil Gaiman,N/A,2001,https://openlibrary.org/works/OL679358W
+Marc Chagall,"Marc Chagall, Evgenija Petrova, Aleksandra Shatskikh",N/A,1948,https://openlibrary.org/works/OL4875453W
+Shades of Grey,E. L. James,N/A,2011,https://openlibrary.org/works/OL16550682W
+Evelina,"Fanny Burney, Frances Burney",N/A,1778,https://openlibrary.org/works/OL2252006W
+Things Fall Apart,Chinua Achebe,N/A,1958,https://openlibrary.org/works/OL891786W
+Brideshead Revisited,Evelyn Waugh,N/A,1945,https://openlibrary.org/works/OL5721394W
+A Modern Utopia,H. G. Wells,N/A,1900,https://openlibrary.org/works/OL52256W
+Архипелаг ГУЛАГ,Александр Исаевич Солженицын,N/A,1970,https://openlibrary.org/works/OL272388W
+The Thirteen Problems,Agatha Christie,N/A,1932,https://openlibrary.org/works/OL471921W
+The Hunting of the Snark,Lewis Carroll,N/A,1876,https://openlibrary.org/works/OL151447W
+Tropic of Cancer,Henry Miller,N/A,1934,https://openlibrary.org/works/OL261866W
+The Left Hand of Darkness,Ursula K. Le Guin,N/A,1969,https://openlibrary.org/works/OL59800W
+The well of loneliness,Radclyffe Hall,N/A,1928,https://openlibrary.org/works/OL3297469W
+Crime and Punishment,Фёдор Михайлович Достоевский,N/A,1866,https://openlibrary.org/works/OL40766966W
+The lovely bones,"Alice Sebold, Dunow and Carlson Lit. Agency, Maria Roura Mir",N/A,2000,https://openlibrary.org/works/OL5962664W
+Jurassic Park,Michael Crichton,N/A,1990,https://openlibrary.org/works/OL46881W
+Cat Among the Pigeons,Agatha Christie,N/A,1959,https://openlibrary.org/works/OL471641W
+Vol de nuit,Antoine de Saint-Exupéry,N/A,1931,https://openlibrary.org/works/OL10267W
+Hallowe'en Party,Agatha Christie,N/A,1969,https://openlibrary.org/works/OL471832W
+Way to wealth,Benjamin Franklin,N/A,1758,https://openlibrary.org/works/OL26610W
+Ben Hur,Lew Wallace,N/A,1800,https://openlibrary.org/works/OL240210W
+They Came to Baghdad,Agatha Christie,N/A,1951,https://openlibrary.org/works/OL472215W
+Roughing It,Mark Twain,N/A,1872,https://openlibrary.org/works/OL54059W
+Игрокъ,Фёдор Михайлович Достоевский,N/A,1900,https://openlibrary.org/works/OL166923W
+The Stand,Stephen King,N/A,1978,https://openlibrary.org/works/OL81618W
+Tales from Shakespeare [20 tales],"Charles Lamb, Mary Lamb",N/A,1800,https://openlibrary.org/works/OL44841W
+Aesop's Fables,Aesop,N/A,1848,https://openlibrary.org/works/OL12129731W
+Crónica de una muerte anunciada,Gabriel García Márquez,N/A,1980,https://openlibrary.org/works/OL274574W
+The Man in the High Castle,"Philip K. Dick, Michelle Charrier",N/A,1962,https://openlibrary.org/works/OL2172403W
+The Sittaford Mystery,Agatha Christie,N/A,1931,https://openlibrary.org/works/OL471664W
+Physics,Aristotle,N/A,1472,https://openlibrary.org/works/OL151632W
+The Blithedale Romance,Nathaniel Hawthorne,N/A,1852,https://openlibrary.org/works/OL455512W
+L'Île mystérieuse,Jules Verne,N/A,1870,https://openlibrary.org/works/OL1099915W
+The Ambassadors,Henry James,N/A,1903,https://openlibrary.org/works/OL276470W
+Dumb Witness,Agatha Christie,N/A,1937,https://openlibrary.org/works/OL472189W
+Storm Island,Ken Follett,N/A,1978,https://openlibrary.org/works/OL1914088W
+Eclipse,Stephenie Meyer,N/A,2006,https://openlibrary.org/works/OL5720025W
+Bury My Heart at Wounded Knee,Dee Alexander Brown,N/A,1672,https://openlibrary.org/works/OL14864823W
+Eragon,Christopher Paolini,N/A,1998,https://openlibrary.org/works/OL5819895W
+Mutual Aid,Peter Kropotkin,N/A,1902,https://openlibrary.org/works/OL1105375W
+The Tenant of Wildfell Hall,Anne Brontë,N/A,1847,https://openlibrary.org/works/OL260101W
+The Crucible,Arthur Miller,N/A,1953,https://openlibrary.org/works/OL66347W
+Baron Trump's Marvelous Underground Journey,Ingersoll Lockwood,N/A,1893,https://openlibrary.org/works/OL8883287W
+Edvard Munch,"Edvard Munch, Christoph Asendorf, Marian Bisanz-Prakken, Albrecht Schröder, Albertina Wien, Dieter Buchhart, Antonia Hoerschelmann, Frank Hoifodt, Iris Müller-Westermann, Gerd Woll, Arne Eggum, Reinhold Heller, Carla Lathe",N/A,1927,https://openlibrary.org/works/OL136192W
+Do Androids Dream of Electric Sheep?,Philip K. Dick,N/A,1968,https://openlibrary.org/works/OL2172356W
+Dead Man's Folly,Agatha Christie,N/A,1956,https://openlibrary.org/works/OL471713W
+"Maria; or, The Wrongs of Woman","Mary Wollstonecraft, William Godwin",N/A,1799,https://openlibrary.org/works/OL849217W
+The Mysterious Stranger,Mark Twain,N/A,1916,https://openlibrary.org/works/OL54158W
+Richard III,William Shakespeare,N/A,1597,https://openlibrary.org/works/OL362684W
+The Narrative of Arthur Gordon Pym,Edgar Allan Poe,N/A,1838,https://openlibrary.org/works/OL40962W
+The Magic World,Edith Nesbit,N/A,1959,https://openlibrary.org/works/OL7984948W
+Black Beauty,"Anna Sewell, Mrs. J. C. Gorham ",N/A,1877,https://openlibrary.org/works/OL40252W
+Rights of Man,"Thomas Paine, T. Paine, Thomas Thomas Paine",N/A,1791,https://openlibrary.org/works/OL60359W
+Φαίδων,Πλάτων,N/A,1713,https://openlibrary.org/works/OL51805W
+Death of a Salesman,Arthur Miller,N/A,1940,https://openlibrary.org/works/OL66346W
+New Moon,Stephenie Meyer,N/A,2006,https://openlibrary.org/works/OL5720027W
+Picasso,William S. Lieberman,N/A,1930,https://openlibrary.org/works/OL145190W
+El coronel no tiene quien le escriba,"Gabriel García Márquez, Luisa Rivera",N/A,1961,https://openlibrary.org/works/OL274509W
+Murder is Easy,Agatha Christie,N/A,1939,https://openlibrary.org/works/OL472582W
+Rilla of Ingleside,Lucy Maud Montgomery,N/A,1920,https://openlibrary.org/works/OL77757W
+The Pelican Brief,John Grisham,N/A,1992,https://openlibrary.org/works/OL76965W
+Белые ночи,Фёдор Михайлович Достоевский,N/A,1958,https://openlibrary.org/works/OL166952W
+Third Girl,Agatha Christie,N/A,1966,https://openlibrary.org/works/OL472536W
+The  black arrow,Robert Louis Stevenson,N/A,1888,https://openlibrary.org/works/OL24161W
+Livro do Desassossego,Fernando Pessoa,N/A,1982,https://openlibrary.org/works/OL847061W
+Germinal,Émile Zola,N/A,1885,https://openlibrary.org/works/OL118986W
+Buddenbrooks,Thomas Mann,N/A,1909,https://openlibrary.org/works/OL14867081W
+Captains Courageous,Rudyard Kipling,N/A,1896,https://openlibrary.org/works/OL19842W
+The Once and Future King,T. H. White,N/A,1939,https://openlibrary.org/works/OL1388028W
+L'Homme révolté,Albert Camus,N/A,1951,https://openlibrary.org/works/OL1230600W
+Il Paradiso,Dante Alighieri,N/A,1595,https://openlibrary.org/works/OL93230W
+Fables,Jean de La Fontaine,N/A,1678,https://openlibrary.org/works/OL50348W
+Breaking Dawn,Stephenie Meyer,N/A,2008,https://openlibrary.org/works/OL5720022W
+Herland,Charlotte Perkins Gilman,N/A,1915,https://openlibrary.org/works/OL2771987W
+The Life and Adventures of Nicholas Nickleby,Charles Dickens,N/A,1800,https://openlibrary.org/works/OL13114895W
+The Runaway Jury,John Grisham,N/A,1996,https://openlibrary.org/works/OL76984W
+Milton's Poems,John Milton,N/A,1605,https://openlibrary.org/works/OL810990W
+The Agony and the Ecstasy,Irving Stone,N/A,1958,https://openlibrary.org/works/OL112002W
+A Raisin in the Sun,Lorraine Hansberry,N/A,1958,https://openlibrary.org/works/OL2916090W
+Hänsel und Gretel,Gebrüder Grimm [Brothers Grimm],N/A,1900,https://openlibrary.org/works/OL15227626W
+Metamorphoses,"Lucius Apuleius, William Adlington, Lucio Apuleyo, pixabay",N/A,1500,https://openlibrary.org/works/OL658250W
+Bridget Jones's Diary,"Helen Fielding, Helen Fielding",N/A,1996,https://openlibrary.org/works/OL547745W
+The Seven Dials Mystery,Agatha Christie,N/A,1929,https://openlibrary.org/works/OL471784W
+Sapiens,"Yuval Noah Harari, Daniel Casanave, David Vandermeulen, Pierre-Emmanuel Dauzat, Joandomènec Ros i Aragonès, Andoni Sagarna, Xabier Kintana, David Casanave",N/A,2011,https://openlibrary.org/works/OL17075811W
+Kokoro,"夏目漱石, Yoko Ogihara, Fernando Cordobés, Carlos Rubio lópez de la Llave, Nagi Yoshizaki, Makiko Itoh",N/A,1914,https://openlibrary.org/works/OL1174972W
+The Client,John Grisham,N/A,1993,https://openlibrary.org/works/OL77022W
+Two Treatises on Government,"John Locke, Ian Shapiro, Lee Ward",N/A,1689,https://openlibrary.org/works/OL880131W
+Five on a Treasure Island,Enid Blyton,N/A,1942,https://openlibrary.org/works/OL1948704W
+The Art of Public Speaking,Stephen E. Lucas,N/A,1983,https://openlibrary.org/works/OL280772W
+Interview With the Vampire,Anne Rice,N/A,1976,https://openlibrary.org/works/OL77826W
+Papillon,Henri Charrière,N/A,1969,https://openlibrary.org/works/OL262984W
+Taken at the Flood,Agatha Christie,N/A,1900,https://openlibrary.org/works/OL472279W
+The Haunted Hotel,Wilkie Collins,N/A,1878,https://openlibrary.org/works/OL176025W
+Our Man in Havana,"Graham Greene, graham greene",N/A,1958,https://openlibrary.org/works/OL106074W
+Bill,Canada. Legislature. Legislative Assembly.,N/A,2002,https://openlibrary.org/works/OL12210420W
+I Capture the Castle,Dodie Smith,N/A,1948,https://openlibrary.org/works/OL1518582W
+Dom Casmurro,Joaquim Maria Machado de Assis,N/A,1900,https://openlibrary.org/works/OL1003040W
+A tree grows in Brooklyn,Betty Smith,N/A,1943,https://openlibrary.org/works/OL78359W
+The complete poetical works,Robert Burns,N/A,1786,https://openlibrary.org/works/OL766052W
+The History of Tom Jones,Henry Fielding,N/A,1749,https://openlibrary.org/works/OL45623W
+The French Lieutenant's Woman,John Fowles,N/A,1967,https://openlibrary.org/works/OL15010W
+The Outsiders,"S. E. Hinton, Jim Fyfe, Jodi Picoult",N/A,1967,https://openlibrary.org/works/OL2718328W
+The Drawing of the Three,Stephen King,N/A,1987,https://openlibrary.org/works/OL81616W
+The Illustrated Man,Ray Bradbury,N/A,1901,https://openlibrary.org/works/OL103128W
+The Thorn Birds,"Colleen McCullough, Colleen McCullough",N/A,1977,https://openlibrary.org/works/OL1882556W
+Babbitt,Sinclair Lewis,N/A,1922,https://openlibrary.org/works/OL51148W
+Reminiscences of a stock operator,"Edwin Lefèvre, Price Tim, Roger Lowenstein, Richard Richard Wyckoff, Richard D. Wyckoff, Richard D. Wyckoff",N/A,1923,https://openlibrary.org/works/OL3472215W
+Satyricon,Petronius,N/A,1575,https://openlibrary.org/works/OL503861W
+At the Back of the North Wind,George MacDonald,N/A,1871,https://openlibrary.org/works/OL15451W
+Andy Warhol,Andy Warhol,N/A,1967,https://openlibrary.org/works/OL644644W
+Le mythe de Sisyphe,Albert Camus,N/A,1941,https://openlibrary.org/works/OL1230601W
+"Imperializm, kak vysshai͡a︡ stadii͡a︡ kapitalizma",Vladimir Il’ich Lenin,N/A,1900,https://openlibrary.org/works/OL1595934W
+Mrs. McGinty's Dead,Agatha Christie,N/A,1951,https://openlibrary.org/works/OL472044W
+L'être et le néant,Jean-Paul Sartre,N/A,1943,https://openlibrary.org/works/OL1161325W
+The Exorcist,William Peter Blatty,N/A,1971,https://openlibrary.org/works/OL927199W
+El filibusterismo,José Rizal,N/A,1900,https://openlibrary.org/works/OL1622748W
+A Wizard of Earthsea,Ursula K. Le Guin,N/A,1968,https://openlibrary.org/works/OL59798W
+The Lost World,Michael Crichton,N/A,1995,https://openlibrary.org/works/OL46876W
+Nostromo,Joseph Conrad,N/A,1900,https://openlibrary.org/works/OL38700W
+The Amber Spyglass,Philip Pullman,N/A,1999,https://openlibrary.org/works/OL28996W
+Nesnesitelná lehkost bytí,Milan Kundera,N/A,1984,https://openlibrary.org/works/OL8972751W
+Tortilla Flat,John Steinbeck,N/A,1935,https://openlibrary.org/works/OL23201W
+Briefe an einen jungen Dichter,Rainer Maria Rilke,N/A,1929,https://openlibrary.org/works/OL16027499W
+Domestic medicine,"William Buchan M.D., William Nisbet",N/A,1769,https://openlibrary.org/works/OL3715685W
+Saint Francis of Assisi,"Gilbert Keith Chesterton, Doyle Kim, Chesterton Books Staff, S. C. G. Jerome",N/A,1923,https://openlibrary.org/works/OL76399W
+O Pioneers!,Willa Cather,N/A,1913,https://openlibrary.org/works/OL12795W
+The sword in the stone,T. H. White,N/A,1938,https://openlibrary.org/works/OL1388027W
+Fifty Shades Darker,E. L. James,N/A,2011,https://openlibrary.org/works/OL16550681W
+The Mill on the Floss,George Eliot,N/A,1800,https://openlibrary.org/works/OL20938W
+Hatchet,Gary Paulsen,N/A,1986,https://openlibrary.org/works/OL8125760W
+A Pocket Full of Rye,Agatha Christie,N/A,1953,https://openlibrary.org/works/OL472619W
+Digital Fortress,Dan Brown,N/A,1998,https://openlibrary.org/works/OL76836W
+The Rainbow,D. H. Lawrence,N/A,1915,https://openlibrary.org/works/OL81293W
+Briefe an Milena,Franz Kafka,N/A,1952,https://openlibrary.org/works/OL498788W
+The Fault in Our Stars,John Green,N/A,2010,https://openlibrary.org/works/OL16444438W
+The Chamber,John Grisham,N/A,1994,https://openlibrary.org/works/OL77002W
+Zen and the Art of Motorcycle Maintenance,Robert M. Pirsig,N/A,1974,https://openlibrary.org/works/OL827357W
+Abraham Lincoln,Carl Sandburg,N/A,1926,https://openlibrary.org/works/OL1164736W
+The Open Society and Its Enemies (1+2),Karl Popper,N/A,1945,https://openlibrary.org/works/OL1984583W
+Utilitarianism,John Stuart Mill,N/A,1863,https://openlibrary.org/works/OL1068100W
+The Labours of Hercules,Agatha Christie,N/A,1947,https://openlibrary.org/works/OL471948W
+The 7 Habits of Highly Effective People,"Stephen R. Covey, Sean Covey",N/A,1989,https://openlibrary.org/works/OL2629977W
+Foundation and Empire,Isaac Asimov,N/A,1945,https://openlibrary.org/works/OL46224W
+À la recherche du temps perdu,Marcel Proust,N/A,1919,https://openlibrary.org/works/OL1190289W
+Hickory Dickory Death,Agatha Christie,N/A,1955,https://openlibrary.org/works/OL471577W
+Financial audit,United States. General Accounting Office,N/A,1943,https://openlibrary.org/works/OL565229W
+The Magic Finger,Roald Dahl,N/A,1966,https://openlibrary.org/works/OL45876W
+The Tragedy of Pudd'nhead Wilson,Mark Twain,N/A,1758,https://openlibrary.org/works/OL54056W
+"Brown Bear, Brown Bear, What Do You See?","Bill Martin Jr., Eric Carle",N/A,1967,https://openlibrary.org/works/OL59133W
+"The Federalist, or, The New Constitution","Alexander Hamilton, James Madison, John Jay",N/A,1788,https://openlibrary.org/works/OL284420W
+The lady of the lake,Sir Walter Scott,N/A,1800,https://openlibrary.org/works/OL863809W
+The Confidence Man,Herman Melville,N/A,1857,https://openlibrary.org/works/OL102721W
+The Comedy of Errors,William Shakespeare,N/A,1734,https://openlibrary.org/works/OL362679W
+Towards Zero,Agatha Christie,N/A,1944,https://openlibrary.org/works/OL472328W
+The Voyages of Doctor Dolittle,Hugh Lofting,N/A,1922,https://openlibrary.org/works/OL1449063W
+I Know Why the Caged Bird Sings,Maya Angelou,N/A,1969,https://openlibrary.org/works/OL80021W
+Frygt og Bæven,Søren Kierkegaard,N/A,1843,https://openlibrary.org/works/OL112736W
+Nine Stories,J. D. Salinger,N/A,1948,https://openlibrary.org/works/OL3335290W
+The Bad Beginning,Lemony Snicket,N/A,1999,https://openlibrary.org/works/OL15104144W
+Second Foundation,Isaac Asimov,N/A,1953,https://openlibrary.org/works/OL46309W
+Como agua para chocolate,"Laura Esquivel, Esquivel, Laura. Christensen, Carol, Translator.Christensen, Thomas, Translator.",N/A,1989,https://openlibrary.org/works/OL953162W
+Art Through the Ages,Helen Gardner,N/A,1926,https://openlibrary.org/works/OL3002703W
+King Richard II,William Shakespeare,N/A,1597,https://openlibrary.org/works/OL362665W
+Jacob's Room,Virginia Woolf,N/A,1922,https://openlibrary.org/works/OL39329W
+Little Dorrit,"Charles Dickens, Mary Sebag-Montefiore, Adam Leverton",N/A,1800,https://openlibrary.org/works/OL14869215W
+The moon and sixpence,William Somerset Maugham,N/A,1919,https://openlibrary.org/works/OL505740W
+La Fiesta del Chivo,Mario Vargas Llosa,N/A,2000,https://openlibrary.org/works/OL857600W
+The Last Days of Pompeii,"Edward Bulwer Lytton, Baron Lytton",N/A,1800,https://openlibrary.org/works/OL61867W
+Flowers in the Attic,V. C. Andrews,N/A,1979,https://openlibrary.org/works/OL134834W
+Stranger in a Strange Land,Robert A. Heinlein,N/A,1961,https://openlibrary.org/works/OL59688W
+Microbiology,"Gerard J. Tortora, Berdell R. Funke, Christine L. Case",N/A,1982,https://openlibrary.org/works/OL1827302W
+Les damnés de la terre,Frantz Fanon,N/A,1961,https://openlibrary.org/works/OL1323773W
+Flowers for Algernon,Daniel Keyes,N/A,1966,https://openlibrary.org/works/OL515754W
+"A System of Logic, Ratiocinative and Inductive","John Stuart Mill, Louis Peisse",N/A,1843,https://openlibrary.org/works/OL1068214W
+The Enchanted April,Elizabeth von Arnim,N/A,1922,https://openlibrary.org/works/OL8202750W
+The Partner,John Grisham,N/A,1997,https://openlibrary.org/works/OL77004W
+Endless Night,Agatha Christie,N/A,1967,https://openlibrary.org/works/OL472508W
+The Lost Princess of Oz,L. Frank Baum,N/A,1917,https://openlibrary.org/works/OL18411W
+Managerial Accounting,Jerry J. Weygandt,N/A,1999,https://openlibrary.org/works/OL1881227W
+Cujo,Stephen King,N/A,1981,https://openlibrary.org/works/OL81610W
+A Time to Kill,John Grisham,N/A,1989,https://openlibrary.org/works/OL77001W
+Thumbelina,"Hans Christian Andersen, Elsa Beskow, Michael Foreman, Michael Morpurgo, Kimberley Reynolds, Catherine Babok, Susannah Mary Paull",N/A,1911,https://openlibrary.org/works/OL15049906W
+Anne of Ingleside,Lucy Maud Montgomery,N/A,1939,https://openlibrary.org/works/OL77747W
+The reluctant dragon,"Kenneth Grahame, Jim Weiss, Ernest H. Shepard, Michael Hague, Kenneth Grahame, Kenneth Kenneth Grahame, Grahame Kenneth",N/A,1938,https://openlibrary.org/works/OL69602W
+Alias Grace,Margaret Atwood,N/A,1996,https://openlibrary.org/works/OL675834W
+Colloquia,Desiderius Erasmus,N/A,1519,https://openlibrary.org/works/OL679943W
+The Sea of Monsters,Rick Riordan,N/A,2006,https://openlibrary.org/works/OL492646W
+John Barleycorn,Jack London,N/A,1913,https://openlibrary.org/works/OL144798W
+The Runaway Bunny,Margaret Wise Brown,N/A,1942,https://openlibrary.org/works/OL151861W
+Solaris,Stanisław Lem,N/A,1961,https://openlibrary.org/works/OL109524W
+The Enormous Crocodile,"Roald Dahl, Quentin Blake",N/A,1978,https://openlibrary.org/works/OL45881W
+The natural,"Bernard Malamud, SparkNotes Staff",N/A,1952,https://openlibrary.org/works/OL1937853W
+"Etiquette in society, in business, in politics and at home",Emily Post,N/A,1922,https://openlibrary.org/works/OL3640513W
+Native Son,"Richard Wright, Richard Wright - undifferentiated, Richard Wright",N/A,1940,https://openlibrary.org/works/OL275128W
+"So long, and thanks for all the fish",Douglas Adams,N/A,1984,https://openlibrary.org/works/OL2163719W
+The Martian,Andy Weir,N/A,2011,https://openlibrary.org/works/OL17091839W
+Island of the Blue Dolphins,Scott O'Dell,N/A,1960,https://openlibrary.org/works/OL4466828W
+"Men are From Mars, Women are From Venus","John Gray, John Gray, John [Ph.D] Gray",N/A,1992,https://openlibrary.org/works/OL263458W
+The Day of the Jackal,Frederick Forsyth,N/A,1971,https://openlibrary.org/works/OL7923819W
+Schweizerische Robinson,Johann David Wyss,N/A,1828,https://openlibrary.org/works/OL15406011W
+Accounting Principles,Jerry J. Weygandt,N/A,1987,https://openlibrary.org/works/OL1881226W
+The Bridge of San Luis Rey,"Thornton Wilder, T. Wilder, Wilder T.",N/A,1927,https://openlibrary.org/works/OL482894W
+Die Entwicklung des Sozialismus von der Utopie zur Wissenschaft,Friedrich Engels,N/A,1880,https://openlibrary.org/works/OL303509W
+The Empty House and Other Ghost Stories,Algernon Blackwood,N/A,1906,https://openlibrary.org/works/OL2700647W
+Travels with Charley,John Steinbeck,N/A,1962,https://openlibrary.org/works/OL23192W
+Quo Vadis?,Henryk Sienkiewicz,N/A,1896,https://openlibrary.org/works/OL503494W
+The Chosen,"Chaim Potok, Jonathan Davis",N/A,1966,https://openlibrary.org/works/OL1812090W
+The Red House Mystery,A. A. Milne,N/A,1922,https://openlibrary.org/works/OL476846W
+A Passage to India,E. M. Forster,N/A,1924,https://openlibrary.org/works/OL88883W
+Os Lusíadas,"Luís de Camões, Souza Botelho",N/A,1572,https://openlibrary.org/works/OL848771W
+Live and let die,Ian Fleming,N/A,1954,https://openlibrary.org/works/OL85746W
+Passenger to Frankfurt,Agatha Christie,N/A,1970,https://openlibrary.org/works/OL472159W
+The Mysteries of Udolpho,Ann Radcliffe,N/A,1794,https://openlibrary.org/works/OL695211W
+Voskresenīe,Лев Толстой,N/A,1899,https://openlibrary.org/works/OL457760W
+Dragonflight,Anne McCaffrey,N/A,1968,https://openlibrary.org/works/OL73387W
+The Haunted Bookshop,Christopher Morley,N/A,1919,https://openlibrary.org/works/OL619317W
+Ficciones,Jorge Luis Borges,N/A,1945,https://openlibrary.org/works/OL110971W
+The Dispossessed,Ursula K. Le Guin,N/A,1974,https://openlibrary.org/works/OL59863W
+Life of Pi,Yann Martel,N/A,2001,https://openlibrary.org/works/OL2827199W
+Witch Wood,John Buchan,N/A,1927,https://openlibrary.org/works/OL76578W
+American Gods,Neil Gaiman,N/A,2001,https://openlibrary.org/works/OL679360W
+Ecclesiastical history,"Eusebius of Caesarea, Bishop of Caesarea",N/A,1476,https://openlibrary.org/works/OL14833W
+A Torre Negra,Stephen King,N/A,1991,https://openlibrary.org/works/OL81625W
+The Eye of the World (The Wheel of Time Book 1),Robert Jordan,N/A,1990,https://openlibrary.org/works/OL7924103W
+Good Omens,"Neil Gaiman, Terry Pratchett",N/A,1990,https://openlibrary.org/works/OL453936W
+Heretics,Gilbert Keith Chesterton,N/A,1905,https://openlibrary.org/works/OL76482W
+Kane & Abel,Jeffrey Archer,N/A,1979,https://openlibrary.org/works/OL1807144W
+Autobiografía Malcolm X,"Alex Haley, Malcolm X",N/A,1965,https://openlibrary.org/works/OL1815443W
+The Cat of Bubastes,G. A. Henty,N/A,1888,https://openlibrary.org/works/OL1794662W
+The Price of Salt,Patricia Highsmith,N/A,1952,https://openlibrary.org/works/OL59448W
+Poema de mio Cid,Anonymous,N/A,1868,https://openlibrary.org/works/OL886738W
+The power and the Glory,Graham Greene,N/A,1940,https://openlibrary.org/works/OL106084W
+The Story of Ferdinand,"Munro Leaf, Robert Lawson",N/A,1936,https://openlibrary.org/works/OL4649312W
+The Talented Mr. Ripley,Patricia Highsmith,N/A,1955,https://openlibrary.org/works/OL59434W
+Firestarter,Stephen King,N/A,1980,https://openlibrary.org/works/OL81623W
+Wizard and Glass,Stephen King,N/A,1997,https://openlibrary.org/works/OL81615W
+The Road,Cormac McCarthy,N/A,2006,https://openlibrary.org/works/OL40873W
+Les 120 Journées de Sodome,Marquis de Sade,N/A,1953,https://openlibrary.org/works/OL962210W
+An Old-Fashioned Girl,Louisa May Alcott,N/A,1869,https://openlibrary.org/works/OL29970W
+Meditations,"Marcus Aurelius, Gregory Hays, Ryan Holiday",N/A,2006,https://openlibrary.org/works/OL28521353W
+En attendant Godot,Samuel Beckett,N/A,1952,https://openlibrary.org/works/OL15164672W
+The Nine Tailors,Dorothy L. Sayers,N/A,1934,https://openlibrary.org/works/OL2234946W
+Государство и революция,Vladimir Il’ich Lenin,N/A,1900,https://openlibrary.org/works/OL301143W
+Poems,Percy Bysshe Shelley,N/A,1800,https://openlibrary.org/works/OL14853463W
+The Magician,William Somerset Maugham,N/A,1908,https://openlibrary.org/works/OL505730W
+The Seven Lamps of Architecture,John Ruskin,N/A,1800,https://openlibrary.org/works/OL88638W
+Il pendolo di Foucault,Umberto Eco,N/A,1988,https://openlibrary.org/works/OL8996438W
+De consolatione philosophiae,Boethius,N/A,1483,https://openlibrary.org/works/OL1393130W
+Sad Cypress,Agatha Christie,N/A,1939,https://openlibrary.org/works/OL471870W
+Один день Ивана Денисовича,Александр Исаевич Солженицын,N/A,1960,https://openlibrary.org/works/OL258329W
+The worldly philosophers,Robert L. Heilbroner,N/A,1953,https://openlibrary.org/works/OL1847023W
+Ten Days That Shook the World,John Reed,N/A,1919,https://openlibrary.org/works/OL827976W
+"From Russia, with love",Ian Fleming,N/A,1957,https://openlibrary.org/works/OL85732W
+Voyage au bout de la nuit,Louis-Ferdinand Celine,N/A,1932,https://openlibrary.org/works/OL1287903W
+War and Peace,"Tolstoy, Leo, graf, 1828-1910",N/A,1865,https://openlibrary.org/works/OL36765642W
+The Magic City,Edith Nesbit,N/A,1910,https://openlibrary.org/works/OL99535W
+Das Glasperlenspiel. Sonderausgabe,Hermann Hesse,N/A,1943,https://openlibrary.org/works/OL872724W
+The Vampyre,John William Polidori,N/A,1819,https://openlibrary.org/works/OL3625250W
+Moll Flanders,Daniel Defoe,N/A,1722,https://openlibrary.org/works/OL45139W
+Madeleine,Ludwig Bemelmans,N/A,1920,https://openlibrary.org/works/OL1980945W
+The New York Trilogy,Paul Auster,N/A,1987,https://openlibrary.org/works/OL1682133W
+King Henry IV. Part 1,William Shakespeare,N/A,1598,https://openlibrary.org/works/OL1348798W
+Prometheus Bound,Aeschylus,N/A,1559,https://openlibrary.org/works/OL856902W
+The Velveteen Rabbit,"Margery Williams Bianco, Wendy Cheyette Lewison, Juan Gonzalez Alvaro",N/A,1900,https://openlibrary.org/works/OL812053W
+The earth,"Edward J. Tarbuck, Frederick K. Lutgens",N/A,1984,https://openlibrary.org/works/OL29607W
+The Rainmaker,John Grisham,N/A,1995,https://openlibrary.org/works/OL77021W
+A Clash of Kings,George R. R. Martin,N/A,1998,https://openlibrary.org/works/OL257939W
+Mishneh Torah (Codification of Talmudic laws),Moses Maimonides,N/A,1470,https://openlibrary.org/works/OL158334W
+The Yearling,Marjorie Kinnan Rawlings,N/A,1938,https://openlibrary.org/works/OL111382W
+Rashomon and other stories,"Ryūnosuke Akutagawa, Akira Kurosawa, agustin leiva, Jay Rubin, 村上春樹, Alejandro lucas matias sanchez alonso, Ryunosuke Akutagawa, José Kozer, Albert Nolla Cabellos, . mkdeville, Philippe Nicloux",N/A,1952,https://openlibrary.org/works/OL4188238W
+Hija de la fortuna,Isabel Allende,N/A,1998,https://openlibrary.org/works/OL1905246W
+Educational psychology,"Anita Woolfolk Hoy, Philip H. Winne, Nancy E. Perry, Beth Popiel",N/A,1987,https://openlibrary.org/works/OL2651233W
+Portnoy's Complaint,Philip Roth,N/A,1656,https://openlibrary.org/works/OL74676W
+The Scarlet Letter,"Nathaniel Hawthorne, Austin Warren",N/A,1850,https://openlibrary.org/works/OL25074095W
+Novels (Adventures of Huckleberry Finn / Adventures of Tom Sawyer),Mark Twain,N/A,1922,https://openlibrary.org/works/OL16025215W
+The Tombs of Atuan,Ursula K. Le Guin,N/A,1971,https://openlibrary.org/works/OL59801W
+The Mouse and the Motorcycle,Beverly Cleary,N/A,1965,https://openlibrary.org/works/OL151936W
+Divina Commedia,Dante Alighieri,N/A,1472,https://openlibrary.org/works/OL93082W
+The Adventures of Captain Underpants,Dav Pilkey,N/A,1997,https://openlibrary.org/works/OL14871228W
+Bel-Ami,Guy de Maupassant,N/A,1893,https://openlibrary.org/works/OL93842W
+Light in August,William Faulkner,N/A,1931,https://openlibrary.org/works/OL82931W
+Love's Labour's Lost,William Shakespeare,N/A,1598,https://openlibrary.org/works/OL362686W
+Destination Unknown,Agatha Christie,N/A,1954,https://openlibrary.org/works/OL471738W
+The Haunting of Hill House,Shirley Jackson,N/A,1959,https://openlibrary.org/works/OL3171069W
+Out of the Silent Planet,C.S. Lewis,N/A,1938,https://openlibrary.org/works/OL71166W
+Tales of Terror and Mystery,Arthur Conan Doyle,N/A,1963,https://openlibrary.org/works/OL262586W
+Joy of Cooking,"Irma S. Rombauer, Marion Rombauer Becker, Ethan Becker, John Becker, Megan Scott",N/A,1931,https://openlibrary.org/works/OL267968W
+The Girl Who Loved Tom Gordon,Stephen King,N/A,1999,https://openlibrary.org/works/OL81612W
+Nada,Carmen Laforet,N/A,1945,https://openlibrary.org/works/OL1315149W
+The Edible Woman,Margaret Atwood,N/A,1969,https://openlibrary.org/works/OL675696W
+My Cousin Rachel,Daphne du Maurier,N/A,1900,https://openlibrary.org/works/OL7917311W
+The Eyes of the Dragon,Stephen King,N/A,1959,https://openlibrary.org/works/OL81602W
+Grammatical institute of the English language. Part 1,Noah Webster,N/A,1788,https://openlibrary.org/works/OL15333890W
+Le Corbusier,Le Corbusier,N/A,1938,https://openlibrary.org/works/OL15210196W
+The Snowy Day,"Ezra Jack Keats, Marilyn Sanabria, Shang yi bian ji bu",N/A,1962,https://openlibrary.org/works/OL831023W
+The Remains of the Day,Kazuo Ishiguro,N/A,1989,https://openlibrary.org/works/OL59048W
+Visage volé,"Latifa, Chekeba Hachemi, Mercè Ubach Dorca",N/A,2001,https://openlibrary.org/works/OL5798945W
+The Name of the Wind,Patrick Rothfuss,N/A,2007,https://openlibrary.org/works/OL8479867W
+Doctor Faustus,Thomas Mann,N/A,1947,https://openlibrary.org/works/OL14867080W
+The Professor,Charlotte Brontë,N/A,1856,https://openlibrary.org/works/OL271361W
+Agnes Grey,Anne Brontë,N/A,1847,https://openlibrary.org/works/OL2462427W
+On Writing,Stephen King,N/A,1999,https://openlibrary.org/works/OL81601W
+The Day of the Triffids,"John Wyndham, Marcel Battin, Cover by Andy Bridge",N/A,1951,https://openlibrary.org/works/OL1911336W
+El general en su laberinto,Gabriel García Márquez,N/A,1989,https://openlibrary.org/works/OL274577W
+The Phantom Tollbooth,Norton Juster,N/A,1961,https://openlibrary.org/works/OL1636262W
+Midnight's Children,Salman Rushdie,N/A,1981,https://openlibrary.org/works/OL457179W
+Go Tell It on the Mountain,"James Baldwin, James Baldwin",N/A,1952,https://openlibrary.org/works/OL228705W
+N or M?,Agatha Christie,N/A,1941,https://openlibrary.org/works/OL472130W
+The Golden Notebook,Doris Lessing,N/A,1962,https://openlibrary.org/works/OL31259W
+Frog and Toad Are Friends,Arnold Lobel,N/A,1920,https://openlibrary.org/works/OL449277W
+A strange disappearance,"Anna Katharine Green, Anna Katharine Green, Cyanide Publishing, Anna Katherine Green, Anna Green",N/A,1879,https://openlibrary.org/works/OL4885721W
+"Bartleby, the Scrivener",Herman Melville,N/A,1966,https://openlibrary.org/works/OL102732W
+A Tramp Abroad,Mark Twain,N/A,1878,https://openlibrary.org/works/OL53918W
+Harriet the Spy,Louise Fitzhugh,N/A,1960,https://openlibrary.org/works/OL5277971W
+Psychopathia sexualis,"Richard von Krafft-Ebing, Krafft/",N/A,1886,https://openlibrary.org/works/OL15822096W
+Eight cousins,Louisa May Alcott,N/A,1874,https://openlibrary.org/works/OL17846238W
+Childhood’s End,Arthur C. Clarke,N/A,1953,https://openlibrary.org/works/OL17415W
+A Canticle for Leibowitz,"Walter M. Miller Jr., Волтер Майкл Міллер-молодший",N/A,1959,https://openlibrary.org/works/OL2626638W
+Collected papers,Sigmund Freud,N/A,1906,https://openlibrary.org/works/OL1069221W
+The Ugly American,"William J. Lederer, Eugene Burdick, Eugene BURDICK, William J. LEDERER, Eugene Lederer William J. & Burdick, Lederer, William J.; Burdick, Eugene, William J. and Eugene Burdick Lederer, Eugene Burdick William Julius Lederer, Eugene Burdick William J. Lederer, LEDERER, WILLIAM J., BURDICK, EUGENE, WILLIAM J. LEDERER/EUGENE BURDICK, Eugene. Lederer William J.; Burdick, William Lederer",N/A,1958,https://openlibrary.org/works/OL3951782W
+Atonement,Ian McEwan,N/A,1808,https://openlibrary.org/works/OL1855944W
+"Economics, an introductory analysis","Paul Anthony Samuelson, Nordhaus, William D., William D. Nordhaus",N/A,1948,https://openlibrary.org/works/OL2197894W
+Memoirs of a Geisha,"Arthur Golden, Arthur Golden, Arthur Golden",N/A,1997,https://openlibrary.org/works/OL1856675W
+Grundlegung zur Metaphysik der Sitten,"Immanuel Kant, Jhon Duran, Manuel García Manuel García Morente, Juan Miguel Palacios García, Manuel García Morente",N/A,1785,https://openlibrary.org/works/OL99843W
+The Plains of Passage,Jean M. Auel,N/A,1990,https://openlibrary.org/works/OL2746406W
+The Collector,John Fowles,N/A,1963,https://openlibrary.org/works/OL15008W
+"Life, the Universe and Everything",Douglas Adams,N/A,1900,https://openlibrary.org/works/OL2163623W
+North and South,Elizabeth Cleghorn Gaskell,N/A,1855,https://openlibrary.org/works/OL1103203W
+The Fountainhead,Ayn Rand,N/A,1943,https://openlibrary.org/works/OL731663W
+All the Light We Cannot See,Anthony Doerr,N/A,2014,https://openlibrary.org/works/OL16821606W
+Beautiful Stories from Shakespeare,"Edith Nesbit, William Shakespeare",N/A,1907,https://openlibrary.org/works/OL7984952W
+Ramona the Pest,Beverly Cleary,N/A,1968,https://openlibrary.org/works/OL151964W
+The Dragon and the Raven,"G. A. Henty, Indy Publications",N/A,1800,https://openlibrary.org/works/OL1794685W
+Del sentimiento trágico de la vida en los hombres y en los pueblos,"Miguel de Unamuno, J. E. Crawford Flitch, Miguel de Unamuno, Kenneth L. Patton",N/A,1900,https://openlibrary.org/works/OL503529W
+Voyage Out,Virginia Woolf,N/A,1915,https://openlibrary.org/works/OL27064817W
+Poems,Samuel Taylor Coleridge,N/A,1796,https://openlibrary.org/works/OL26131W
+Eldest,Christopher Paolini,N/A,1998,https://openlibrary.org/works/OL5819886W
+Dotcom Secrets,Russell Brunson,N/A,2011,https://openlibrary.org/works/OL21687423W
+Dune Messiah,Frank Herbert,N/A,1969,https://openlibrary.org/works/OL893526W
+A Little Black Book,Graeme Jenkinson,N/A,2019,https://openlibrary.org/works/OL24393283W
+The Chronicles of Narnia,C.S. Lewis,N/A,1970,https://openlibrary.org/works/OL70988W
+The Gruffalo's Child,Julia Donaldson,N/A,2004,https://openlibrary.org/works/OL1938211W
+Le suicide,Émile Durkheim,N/A,1850,https://openlibrary.org/works/OL606917W
+Νόμοι,Πλάτων,N/A,1562,https://openlibrary.org/works/OL51792W
+Ubik,Philip K. Dick,N/A,1969,https://openlibrary.org/works/OL2172454W
+Romance of the three kingdoms,"Luo Guanzhong, C. H. Brewitt-Taylor",N/A,1644,https://openlibrary.org/works/OL1961811W
+"Advances in Computers, Volume 49 (Advances in Computers)","Marvin V. Zelkowitz, Marshall C. Yovits",N/A,1995,https://openlibrary.org/works/OL7938163W
+The Hunt for Red October,Tom Clancy,N/A,1984,https://openlibrary.org/works/OL159452W
+The Testament,John Grisham,N/A,1999,https://openlibrary.org/works/OL76974W
+The Eagle Has Landed,Jack Higgins,N/A,1975,https://openlibrary.org/works/OL157363W
+The Battle of the Labyrinth,Rick Riordan,N/A,2008,https://openlibrary.org/works/OL492640W
+The tale of Jemima Puddle-Duck,"Beatrix Potter, Colin Twinn, H.Y. Xiao PhD",N/A,1908,https://openlibrary.org/works/OL16067296W
+Heart is a lonely hunter,Carson McCullers,N/A,1940,https://openlibrary.org/works/OL11081469W
+Little Bear,Else Holmelund Minarik,N/A,1957,https://openlibrary.org/works/OL279316W
+De civitate Dei,Augustine of Hippo,N/A,1440,https://openlibrary.org/works/OL137835W
+"Roll of Thunder, Hear My Cry",Mildred D. Taylor,N/A,1976,https://openlibrary.org/works/OL40867W
+Julie of the Wolves,Jean Craighead George,N/A,1972,https://openlibrary.org/works/OL111833W
+A Streetcar Named Desire,Tennessee Williams,N/A,1947,https://openlibrary.org/works/OL30294W
+Legenda aurea,"Jacobus de Voragine, William Caxton",N/A,1476,https://openlibrary.org/works/OL813733W
+Frog and Toad Together,Arnold Lobel,N/A,1971,https://openlibrary.org/works/OL1973422W
+Roots,Alex Haley,N/A,1861,https://openlibrary.org/works/OL1815447W
+The Giraffe and the Pelly and Me,Roald Dahl,N/A,1985,https://openlibrary.org/works/OL45882W
+The Farthest Shore,Ursula K. Le Guin,N/A,1972,https://openlibrary.org/works/OL59855W
+The Emerald City of Oz,L. Frank Baum,N/A,1910,https://openlibrary.org/works/OL18409W
+The Origins of Totalitarianism,Hannah Arendt,N/A,1951,https://openlibrary.org/works/OL10460640W
+La ciudad y los perros,Mario Vargas Llosa,N/A,1963,https://openlibrary.org/works/OL857544W
+Public Speaking and Influencing Men in Business,Dale Carnegie,N/A,1926,https://openlibrary.org/works/OL1063333W
+Ἀνάβασις,Xenophon,N/A,1623,https://openlibrary.org/works/OL687015W
+The Dark Half,Stephen King,N/A,1989,https://openlibrary.org/works/OL81620W
+Три сестры,Антон Павлович Чехов,N/A,1901,https://openlibrary.org/works/OL55419W
+The World Almanac for Kids,"Judith S. Levey, Elaine Israel, Chronicle Staff, World Almanac, Editors of World Almanac, Kevin Seabrooke, Inc. World Almanac Education Group, The Editors of World Almanac, Editors of the World Almanac for Kids, World Almanac Publications, St. Martin's Press, William McGeveran Jr., GREG CAMDEN, Zoe Kashner, Sarah Janssen, World Almanac Books, C. Alan Joyce, Sarah Janssen, Sarah janseen, Sarah Janssen, editor, Sarah Janssen, sarah janssen, The Editors of Time Almanac",N/A,1995,https://openlibrary.org/works/OL2688199W
+Cosmos,Alexander von Humboldt,N/A,1845,https://openlibrary.org/works/OL1554090W
+Memorabilia,Xenophon,N/A,1650,https://openlibrary.org/works/OL687223W
+I promessi sposi,Alessandro Manzoni,N/A,1800,https://openlibrary.org/works/OL644386W
+Death Comes as the End,Agatha Christie,N/A,1944,https://openlibrary.org/works/OL471898W
+Sphere,"Michael Crichton, Jacques Polanis",N/A,1980,https://openlibrary.org/works/OL46917W
+American Government,"James Q. Wilson, John J. DiIulio, Jr",N/A,1980,https://openlibrary.org/works/OL530273W
+Tintenherz,Cornelia Funke,N/A,2003,https://openlibrary.org/works/OL941669W
+Cat on a Hot Tin Roof,Tennessee Williams,N/A,1944,https://openlibrary.org/works/OL30292W
+"The Economics of Money, Banking, and Financial Markets",Frederic S. Mishkin,N/A,1986,https://openlibrary.org/works/OL452451W
+Cat's Cradle,Kurt Vonnegut,N/A,1963,https://openlibrary.org/works/OL98454W
+Henry Huggins,Beverly Cleary,N/A,1950,https://openlibrary.org/works/OL151924W
+A Confederacy of Dunces,John Kennedy Toole,N/A,1980,https://openlibrary.org/works/OL3501723W
+Needful Things,Stephen King,N/A,1991,https://openlibrary.org/works/OL81607W
+Artemis Fowl and the Eternity Code,Eoin Colfer,N/A,2003,https://openlibrary.org/works/OL5725961W
+The gutter in the sky,Jean Genet,N/A,1948,https://openlibrary.org/works/OL1281850W
+Le Mystère de la Chambre Jaune,Gaston Leroux,N/A,1908,https://openlibrary.org/works/OL1833873W
+The Titan's Curse,Rick Riordan,N/A,2007,https://openlibrary.org/works/OL492647W
+"Not a Penny More, Not a Penny Less",Jeffrey Archer,N/A,1974,https://openlibrary.org/works/OL1807075W
+Room on the Broom,Julia Donaldson,N/A,2001,https://openlibrary.org/works/OL1938251W
+Freakonomics,"Steven D. Levitt, Stephen J. Dubner, Andrea Montero Cusset",N/A,2005,https://openlibrary.org/works/OL278022W
+My Secret Life,"Walter, Anonymous",N/A,1966,https://openlibrary.org/works/OL264676W
+The Violet Fairy Book (Large Print),Andrew Lang,N/A,1906,https://openlibrary.org/works/OL1088883W
+Der Vorleser,Bernhard Schlink,N/A,1995,https://openlibrary.org/works/OL14871157W
+The Story of the Treasure Seekers,Edith Nesbit,N/A,1899,https://openlibrary.org/works/OL99522W
+The warlord of Mars #3,"Edgar Rice Burroughs, Jim Killavey, Paula Paula",N/A,1919,https://openlibrary.org/works/OL1418137W
+Rubāʻīyāt,Omar Khayyam,N/A,1870,https://openlibrary.org/works/OL998028W
+The Well at the World's End,William Morris,N/A,1896,https://openlibrary.org/works/OL47750W
+Boston Cooking-School cook book,"Fannie Merritt Farmer, Lincoln, Mary Johnson Bailey ""Mrs. D. A. Lincoln,"", James B. Herndon , Herndon/Vehling Collection, Sam Sloan, D. A. Lincoln",N/A,1896,https://openlibrary.org/works/OL1798750W
+Marketing management,Philip Kotler,N/A,1973,https://openlibrary.org/works/OL1807518W
+The Magus,John Fowles,N/A,1965,https://openlibrary.org/works/OL15028W
+Libro de buen amor,Juan Ruiz,N/A,1900,https://openlibrary.org/works/OL3650890W
+The Roman Breviary,"Catholic Church, John Patrick Crichton-Stuart 3rd Marquess of Bute",N/A,1200,https://openlibrary.org/works/OL349325W
+A Woman of No Importance,Oscar Wilde,N/A,1893,https://openlibrary.org/works/OL14877870W
+Down and Out in Paris and London,George Orwell,N/A,1933,https://openlibrary.org/works/OL1168030W
+Platero y yo,Juan Ramón Jiménez,N/A,1914,https://openlibrary.org/works/OL35093658W
+The Warden,Anthony Trollope,N/A,1809,https://openlibrary.org/works/OL109882W
+"Cry, the Beloved Country",Alan Paton,N/A,1940,https://openlibrary.org/works/OL2384132W
+Why Didn't they Ask Evans?,Agatha Christie,N/A,1935,https://openlibrary.org/works/OL472388W
+The Caves of Steel,Isaac Asimov,N/A,1953,https://openlibrary.org/works/OL46401W
+The anatomy of melancholy,Robert Burton,N/A,1624,https://openlibrary.org/works/OL3149647W
+Four Past Midnight,Stephen King,N/A,1990,https://openlibrary.org/works/OL81606W
+Petals on the Wind,V. C. Andrews,N/A,1980,https://openlibrary.org/works/OL134890W
+The End of Eternity,Isaac Asimov,N/A,1955,https://openlibrary.org/works/OL46108W
+America,"George Brown Tindall, David Emory Shi",N/A,1984,https://openlibrary.org/works/OL480820W
+Hitler,Alan Bullock,N/A,1704,https://openlibrary.org/works/OL31424429W
+La planète des singes,Pierre Boulle,N/A,1963,https://openlibrary.org/works/OL1319418W
+When we were very young,A. A. Milne,N/A,1924,https://openlibrary.org/works/OL476630W
+The dark is rising,Susan Cooper,N/A,1972,https://openlibrary.org/works/OL894245W
+A Feast for Crows,George R. R. Martin,N/A,2005,https://openlibrary.org/works/OL257948W
+A history of the English-speaking peoples,Winston S. Churchill,N/A,1956,https://openlibrary.org/works/OL134334W
+Ann Veronica,H. G. Wells,N/A,1909,https://openlibrary.org/works/OL52258W
+Die Geburt der Tragödie,Friedrich Nietzsche,N/A,1872,https://openlibrary.org/works/OL98152W
+The Street Lawyer,John Grisham,N/A,1989,https://openlibrary.org/works/OL77014W
+These Old Shades,Georgette Heyer,N/A,1926,https://openlibrary.org/works/OL4092686W
+Män som hatar kvinnor,Stieg Larsson,N/A,2005,https://openlibrary.org/works/OL5784622W
+Maus I,Art Spiegelman,N/A,1986,https://openlibrary.org/works/OL2056818W
+An essay on man,Alexander Pope,N/A,1733,https://openlibrary.org/works/OL79353W
+Stardust,Neil Gaiman,N/A,1997,https://openlibrary.org/works/OL15833328W
+海辺のカフカ,村上春樹,N/A,2001,https://openlibrary.org/works/OL2625431W
+The Prime of Miss Jean Brodie,Muriel Spark,N/A,1961,https://openlibrary.org/works/OL26437W
+Measure for Measure,William Shakespeare,N/A,1700,https://openlibrary.org/works/OL259017W
+The Tommyknockers,Stephen King,N/A,1985,https://openlibrary.org/works/OL81593W
+The Joy Luck Club,"Amy Tan, Gwendoline Yeo, Tsai Chin, Ronald Bass, Wayne Wang, Jordi Fibla",N/A,1989,https://openlibrary.org/works/OL1843720W
+The Bonfire of the Vanities,Tom Wolfe,N/A,1987,https://openlibrary.org/works/OL1925470W
+From the Mixed-Up Files of Mrs. Basil E. Frankweiler,"E. L. Konigsburg, Jill Clayburgh",N/A,1967,https://openlibrary.org/works/OL2987238W
+The Children of Húrin,J.R.R. Tolkien,N/A,2001,https://openlibrary.org/works/OL27471W
+Comus,John Milton,N/A,1738,https://openlibrary.org/works/OL810989W
+Long Walk to Freedom,Nelson Mandela,N/A,1994,https://openlibrary.org/works/OL1783377W
+The Silence of the Lambs,Thomas Harris,N/A,1988,https://openlibrary.org/works/OL23481W
+Parzival,"Wolfram von Eschenbach, Gottfried Weber, Hermann Jantzen, Mary Blackwell Sterling, Bernd Schirok, Peter Knecht",N/A,1885,https://openlibrary.org/works/OL1098085W
+The Light Fantastic,"Terry Pratchett, Ernest Riera",N/A,1986,https://openlibrary.org/works/OL453680W
+The Caine mutiny,Herman Wouk,N/A,1951,https://openlibrary.org/works/OL729088W
+The Bluest Eye,Toni Morrison,N/A,1970,https://openlibrary.org/works/OL50565W
+Where the Red Fern Grows,Wilson Rawls,N/A,1961,https://openlibrary.org/works/OL465360W
+The Hiding Place,"Corrie ten Boom, Elizabeth Sherrill, John Sherrill, John Scherrill, Jill De Haan, Daniel Strange",N/A,1971,https://openlibrary.org/works/OL1915012W
+The Shipping News,Annie Proulx,N/A,1993,https://openlibrary.org/works/OL456089W
+The Celestine Prophecy - An Adventure,James Redfield,N/A,1993,https://openlibrary.org/works/OL53168W
+"The Secret Diary of Adrian Mole, Aged 13 3/4",Sue Townsend,N/A,1982,https://openlibrary.org/works/OL549598W
+Neuromancer,William Gibson,N/A,1984,https://openlibrary.org/works/OL27258W
+The Princess and Curdie,George MacDonald,N/A,1832,https://openlibrary.org/works/OL15448W
+Sailing alone around the world,Joshua Slocum,N/A,1800,https://openlibrary.org/works/OL59979W
+The Long Haul,Jeff Kinney,N/A,2000,https://openlibrary.org/works/OL17076678W
+The Five People You Meet in Heaven,Mitch Albom,N/A,2003,https://openlibrary.org/works/OL1822312W
+Night Shift,Stephen King,N/A,1960,https://openlibrary.org/works/OL81608W
+El Aleph,Jorge Luis Borges,N/A,1949,https://openlibrary.org/works/OL110969W
+Goldfinger,Ian Fleming,N/A,1958,https://openlibrary.org/works/OL85750W
+Dear Mr. Henshaw,Beverly Cleary,N/A,1983,https://openlibrary.org/works/OL151997W
+Make Way for Ducklings,"Robert McCloskey, David Crommett",N/A,1941,https://openlibrary.org/works/OL4638367W
+Aura,Carlos Fuentes,N/A,1962,https://openlibrary.org/works/OL872225W
+Mein Weltbild,"Albert Einstein, Neil Berger",N/A,1934,https://openlibrary.org/works/OL1214254W
+Prey,Michael Crichton,N/A,2002,https://openlibrary.org/works/OL46883W
+Cyropaedia,Xenophon,N/A,1527,https://openlibrary.org/works/OL687224W
+Fables,"Aesop, Joseph Jacobs, Roger L'Estrange, Percy J. Billinghurst",N/A,1489,https://openlibrary.org/works/OL15464922W
+Reptile Room,"Lemony Snicket, Brett Helquist, Michael Kupperman, Nestor Busquets",N/A,1999,https://openlibrary.org/works/OL27422475W
+Arms and the Man,George Bernard Shaw,N/A,1898,https://openlibrary.org/works/OL1066525W
+The Law and the Lady,"Wilkie Collins, Camille de Cendrey",N/A,1875,https://openlibrary.org/works/OL176081W
+The King Must Die,Mary Renault,N/A,1952,https://openlibrary.org/works/OL3906336W
+The spy,James Fenimore Cooper,N/A,1821,https://openlibrary.org/works/OL78075W
+La tulipe noire,Alexandre Dumas,N/A,1800,https://openlibrary.org/works/OL36854W
+"Eat, Pray, Love",Elizabeth Gilbert,N/A,2001,https://openlibrary.org/works/OL41815W
+How to live on 24 hours a day,"Arnold Bennett, Jim Roberts",N/A,1900,https://openlibrary.org/works/OL109213W
+Die Welt als Wille und Vorstellung,Arthur Schopenhauer,N/A,1819,https://openlibrary.org/works/OL1183657W
+Herzog,Saul Bellow,N/A,1961,https://openlibrary.org/works/OL15859552W
+The Queen of the Damned,Anne Rice,N/A,1988,https://openlibrary.org/works/OL77828W
+Poems,Alfred Lord Tennyson,N/A,1827,https://openlibrary.org/works/OL15097239W
+Black Boy,Richard Wright,N/A,1945,https://openlibrary.org/works/OL275946W
+雪国,川端康成,N/A,1937,https://openlibrary.org/works/OL2045111W
+Flush,"Virginia Woolf, Eileen Atkins, Katyuli Lloyd, Jose KING, Jordi Fernando, Rafael Vázquez Zamora",N/A,1694,https://openlibrary.org/works/OL39320W
+Where's Spot?,Eric Hill,N/A,1980,https://openlibrary.org/works/OL10619251W
+Practical mysticism,Evelyn Underhill,N/A,1914,https://openlibrary.org/works/OL1101636W
+As I Lay Dying,William Faulkner,N/A,1915,https://openlibrary.org/works/OL82929W
+Saving Faith,David Baldacci,N/A,1999,https://openlibrary.org/works/OL41243W
+Shutter Island,Dennis Lehane,N/A,2003,https://openlibrary.org/works/OL17200W
+The Summons,John Grisham,N/A,2002,https://openlibrary.org/works/OL77016W
+The Glass Menagerie,Tennessee Williams,N/A,1945,https://openlibrary.org/works/OL30293W
+Principles of Macroeconomics,"N. Gregory Mankiw, Robin Stonecash, Joshua Gans, Stephen King, Gregory Mankiw, Ronald Kneebone, Kenneth McKenzie, Nicholas Rowe, Mankiw, Kneebone, McKenzie",N/A,1996,https://openlibrary.org/works/OL270564W
+Timeline,Michael Crichton,N/A,1999,https://openlibrary.org/works/OL46884W
+Mysticism,Evelyn Underhill,N/A,1911,https://openlibrary.org/works/OL1101637W
+The Last Olympian,Rick Riordan,N/A,2009,https://openlibrary.org/works/OL492642W
+A Brief History Of The United States,"Allan Nevins, Henry Steele Commager, Jeffrey Morris",N/A,1942,https://openlibrary.org/works/OL1181798W
+Coriolanus,William Shakespeare,N/A,1734,https://openlibrary.org/works/OL362166W
+Histoire d'O,"Dominique Aury, Guido Crepax",N/A,1954,https://openlibrary.org/works/OL3546951W
+Fuente Ovejuna,Lope de Vega,N/A,1909,https://openlibrary.org/works/OL914527W
+Moments of vision,Thomas Hardy,N/A,1889,https://openlibrary.org/works/OL44912W
+Dandelion Wine,Ray Bradbury,N/A,1946,https://openlibrary.org/works/OL103118W
+Astérix le Gaulois,"René Goscinny, Albert Uderzo",N/A,1961,https://openlibrary.org/works/OL267622W
+The Abhijñānaśākuntalam of Kālidāsa,Kālidāsa,N/A,1789,https://openlibrary.org/works/OL293317W
+The Second Jungle Book,Rudyard Kipling,N/A,1887,https://openlibrary.org/works/OL19926W
+Surfacing,Margaret Atwood,N/A,1972,https://openlibrary.org/works/OL675688W
+Games People Play,Eric Berne,N/A,1964,https://openlibrary.org/works/OL1593567W
+Vios ke Politia tou Alexi Zorba,Nikos Kazantzakis,N/A,1952,https://openlibrary.org/works/OL85509W
+Giovanni's Room,"James Baldwin, james baldwin , James Baldwin ",N/A,1956,https://openlibrary.org/works/OL228702W
+"The Life and Opinions of Tristram Shandy, Gentleman",Laurence Sterne,N/A,1760,https://openlibrary.org/works/OL679230W
+The Lone Wolf,Louis Joseph Vance,N/A,1914,https://openlibrary.org/works/OL7562583W
+Jonathan Livingston Le Goeland,"Richard Bach, Russell Munson, Antonio Ramos Rosa",N/A,1970,https://openlibrary.org/works/OL62073W
+Bring Up the Bodies,Hilary Mantel,N/A,2012,https://openlibrary.org/works/OL16547664W
+On the Banks of Plum Creek,"Laura Ingalls Wilder, Garth Williams",N/A,1937,https://openlibrary.org/works/OL1719794W
+El reino de este mundo,Alejo Carpentier,N/A,1957,https://openlibrary.org/works/OL580014W
+A Greek-English Lexicon,"Henry George Liddell, Robert Scott, Franz Ludwig Carl Friedrich Passow, Robert Scott",N/A,1843,https://openlibrary.org/works/OL2947300W
+Maria (Colección Literatura Universal Alba),Jorge Isaacs,N/A,1800,https://openlibrary.org/works/OL2854179W
+La Petite Sirene (French Well Loved Tales),"Hans Christian Andersen, Yayoi Kusama, Bernadette Watts",N/A,1935,https://openlibrary.org/works/OL15049633W
+Delta of Venus,"Anaïs Nin, N Clarke",N/A,1969,https://openlibrary.org/works/OL278323W
+Invisible Man,Ralph Ellison,N/A,1952,https://openlibrary.org/works/OL495470W
+Swallows and Amazons,"Arthur Michell Ransome, Helen Edmundson, Neil Hannon",N/A,1930,https://openlibrary.org/works/OL2459837W
+Вишневый сад,Антон Павлович Чехов,N/A,1918,https://openlibrary.org/works/OL55417W
+Les Enfants Terribles,Jean Cocteau,N/A,1900,https://openlibrary.org/works/OL963341W
+The Last Straw,Jeff Kinney,N/A,1999,https://openlibrary.org/works/OL15505465W
+Alive!,Piers Paul Read,N/A,1920,https://openlibrary.org/works/OL2563181W
+Nana,Émile Zola,N/A,1880,https://openlibrary.org/works/OL118984W
+The pioneers,James Fenimore Cooper,N/A,1800,https://openlibrary.org/works/OL77997W
+Five Little Peppers and How They Grew,Margaret Sidney,N/A,1880,https://openlibrary.org/works/OL1528785W
+"I, Claudius",Robert Graves,N/A,1934,https://openlibrary.org/works/OL5036952W
+The Vampire Lestat,Anne Rice,N/A,1986,https://openlibrary.org/works/OL77813W
+The Hate U Give,"Angie Thomas, Angie Thomas",N/A,2017,https://openlibrary.org/works/OL17714701W
+Thinner,Stephen King,N/A,1984,https://openlibrary.org/works/OL149210W
+Dinosaurs Before Dark,Mary Pope Osborne,N/A,1992,https://openlibrary.org/works/OL81773W
+"Guns, germs, and steel",Jared M. Diamond,N/A,1997,https://openlibrary.org/works/OL276558W
+Stuart Little,E. B. White,N/A,1945,https://openlibrary.org/works/OL483385W
+Dear Zoo,"Rod Campbell, Roger Boore, Caroline Quentin",N/A,1982,https://openlibrary.org/works/OL587083W
+Passing,Nella Larsen,N/A,1929,https://openlibrary.org/works/OL2645476W
+The Battle of Life,"Charles Dickens, Pradip Das, Edward Stirling, Shahid Akram, Charles Dickens",N/A,1846,https://openlibrary.org/works/OL14868497W
+Cricket in Times Square,"George Selden, Garth Williams",N/A,1960,https://openlibrary.org/works/OL4110995W
+The Willows,Algernon Blackwood,N/A,2002,https://openlibrary.org/works/OL2700635W
+La tregua,Mario Benedetti,N/A,1963,https://openlibrary.org/works/OL741877W
+The Age of Revolution,Eric Hobsbawm,N/A,1962,https://openlibrary.org/works/OL495659W
+Poems,Oscar Wilde,N/A,1881,https://openlibrary.org/works/OL14877876W
+Brighton rock,Graham Greene,N/A,1938,https://openlibrary.org/works/OL106083W
+The God of Small Things,Arundhati Roy,N/A,1997,https://openlibrary.org/works/OL1052138W
+Essays,Ralph Waldo Emerson,N/A,1800,https://openlibrary.org/works/OL62250W
+Song of Solomon,Toni Morrison,N/A,1634,https://openlibrary.org/works/OL50564W
+The No. 1 Ladies' Detective Agency,Alexander McCall Smith,N/A,1997,https://openlibrary.org/works/OL2435522W
+Dragonquest,Anne McCaffrey,N/A,1971,https://openlibrary.org/works/OL73382W
+Origin,Dan Brown,N/A,2013,https://openlibrary.org/works/OL17878702W
+Γοργίας,Πλάτων,N/A,1827,https://openlibrary.org/works/OL51785W
+The Red Pyramid,Rick Riordan,N/A,2009,https://openlibrary.org/works/OL15183119W
+The October Country,Ray Bradbury,N/A,1955,https://openlibrary.org/works/OL103198W
+The Bad Place,Dean Koontz,N/A,1901,https://openlibrary.org/works/OL263256W
+Lorna Doone (Classics),R. D. Blackmore,N/A,1869,https://openlibrary.org/works/OL3686133W
+الروض العاطر في نزهة الخاطر,ʻUmar ibn Muḥammad Nafzāwī,N/A,1886,https://openlibrary.org/works/OL905626W
+Eat That Frog! 21 Great Ways to Stop Procrastinating and Get More Done in Less Time,Brian Tracy,N/A,2001,https://openlibrary.org/works/OL2392324W
+Śmierć Miasta,Władysław Szpilman,N/A,1946,https://openlibrary.org/works/OL15714637W
+Φαῖδρος,Πλάτων,N/A,1792,https://openlibrary.org/works/OL51816W
+Justine,Lawrence Durrell,N/A,1957,https://openlibrary.org/works/OL48302W
+Die unendliche Geschichte,Michael Ende,N/A,1979,https://openlibrary.org/works/OL2271589W
+"The Renaissance, Studies in Art and Poetry",Walter Pater,N/A,1873,https://openlibrary.org/works/OL43676W
+Personal Recollections of Joan of Arc,Mark Twain,N/A,1895,https://openlibrary.org/works/OL54155W
+"Farewell, My Lovely",Raymond Chandler,N/A,1940,https://openlibrary.org/works/OL3295514W
+Sex and the City,Candace Bushnell,N/A,1996,https://openlibrary.org/works/OL2663525W
+Naked Lunch,"William S. Burroughs, William Burroughs",N/A,1959,https://openlibrary.org/works/OL258134W
+Reconfigurable Processor Array A Bit Sliced Parallel Computer (USA),A. Rushton,N/A,1986,https://openlibrary.org/works/OL2829091W
+The holy war,"John Bunyan, Daniel V. Runyon, Derek Perkins",N/A,1682,https://openlibrary.org/works/OL107192W
+Psycho-cybernetics,"Maxwell Maltz, Maxwell maltz, M. Maltz, Maxwell Maltz, Maltz, Maxwell, M.D., F.I.C.S., Naxwell Maltz",N/A,1960,https://openlibrary.org/works/OL99079W
+"Extradition laws and treaties, United States",United States,N/A,1795,https://openlibrary.org/works/OL70052W
+Introductory Mathematical Analysis,"Ernest F. Haeussler, Richard S. Paul",N/A,1973,https://openlibrary.org/works/OL1826387W
+The Story of Little Black Sambo,Helen Bannerman,N/A,1900,https://openlibrary.org/works/OL1521803W
+A Painted House,John Grisham,N/A,2000,https://openlibrary.org/works/OL76991W
+La Nuit,Elie Wiesel,N/A,1955,https://openlibrary.org/works/OL14856842W
+Redwall,Brian Jacques,N/A,1986,https://openlibrary.org/works/OL465952W
+The King of Torts,John Grisham,N/A,1999,https://openlibrary.org/works/OL77011W
+At The Earth's Core And Out Of Time's Abyss,Edgar Rice Burroughs,N/A,1914,https://openlibrary.org/works/OL1417907W
+Emile or Education,"Jean-Jacques Rousseau, Barbara Foxley, William Harold Wayne",N/A,1762,https://openlibrary.org/works/OL80613W
+Tanglewood Tales,Nathaniel Hawthorne,N/A,1853,https://openlibrary.org/works/OL455476W
+"Absalom, Absalom!",William Faulkner,N/A,1936,https://openlibrary.org/works/OL82928W
+The 48 Laws of Power,Robert Greene,N/A,1998,https://openlibrary.org/works/OL1968368W
+Wicked,Gregory Maguire,N/A,1995,https://openlibrary.org/works/OL66218W
+Mort,Terry Pratchett,N/A,1987,https://openlibrary.org/works/OL453658W
+1st to Die,James Patterson,N/A,2001,https://openlibrary.org/works/OL167189W
+Red Dragon,Thomas Harris,N/A,1981,https://openlibrary.org/works/OL23480W
+Self-help,Samuel Smiles,N/A,1800,https://openlibrary.org/works/OL2321834W
+The Scarecrow of Oz,L. Frank Baum,N/A,1915,https://openlibrary.org/works/OL262352W
+Riders of the Purple Sage,Zane Grey,N/A,1912,https://openlibrary.org/works/OL485504W
+Can you forgive her?,Anthony Trollope,N/A,1864,https://openlibrary.org/works/OL109868W
+Something Wicked This Way Comes,Ray Bradbury,N/A,1962,https://openlibrary.org/works/OL103194W
+The Notebook,Nicholas Sparks,N/A,1996,https://openlibrary.org/works/OL54797W
+The Problem of Pain,"C.S. Lewis, James Simmons",N/A,1940,https://openlibrary.org/works/OL71167W
+Runaway Ralph,Beverly Cleary,N/A,1970,https://openlibrary.org/works/OL151956W
+Looking for Alaska,John Green,N/A,2005,https://openlibrary.org/works/OL265426W
+Nightmare Abbey,Thomas Love Peacock,N/A,1818,https://openlibrary.org/works/OL2713465W
+Different Seasons,Stephen King,N/A,1982,https://openlibrary.org/works/OL81621W
+The Brethren,John Grisham,N/A,2000,https://openlibrary.org/works/OL76980W
+Foundation's Edge,Isaac Asimov,N/A,1977,https://openlibrary.org/works/OL46302W
+Everything's Eventual. 14 Dark Tales,Stephen King,N/A,2002,https://openlibrary.org/works/OL81584W
+Antigone,Sophocles,N/A,1835,https://openlibrary.org/works/OL15902218W
+The Princess and the Goblin,George MacDonald,N/A,1872,https://openlibrary.org/works/OL15449W
+Lost Horizon,James Hilton,N/A,1933,https://openlibrary.org/works/OL2455093W
+Jaws,Peter Benchley,N/A,1973,https://openlibrary.org/works/OL3454854W
+Biology,"Neil Alexander Campbell, Lawrence G. Mitchell, Jane B. Reece",N/A,1994,https://openlibrary.org/works/OL1983083W
+The Lost Hero,Rick Riordan,N/A,2010,https://openlibrary.org/works/OL15401200W
+The Corrections,Jonathan Franzen,N/A,2001,https://openlibrary.org/works/OL4082696W
+The Foundation Trilogy,Isaac Asimov,N/A,1950,https://openlibrary.org/works/OL46390W
+Guards! Guards!,Terry Pratchett,N/A,1989,https://openlibrary.org/works/OL453735W
+Literary works of Leonardo da Vinci,Leonardo da Vinci,N/A,1883,https://openlibrary.org/works/OL695407W
+The Man Who Mistook His Wife for a Hat and Other Clinical Tales,Oliver Sacks,N/A,1980,https://openlibrary.org/works/OL1811898W
+No Logo,"Naomi Klein, Naomi Klein",N/A,1957,https://openlibrary.org/works/OL6017245W
+Philosophical essays concerning human understanding,David Hume,N/A,1900,https://openlibrary.org/works/OL93547W
+The moon is a harsh mistress,Robert A. Heinlein,N/A,1965,https://openlibrary.org/works/OL59704W
+The Long Winter,"Laura Ingalls Wilder, Garth Williams",N/A,1940,https://openlibrary.org/works/OL1719759W
+Chronicles of Avonlea,Lucy Maud Montgomery,N/A,1912,https://openlibrary.org/works/OL77788W
+The Killer Angels,Michael Shaara,N/A,1974,https://openlibrary.org/works/OL82664W
+Cabin Fever,Jeff Kinney,N/A,2007,https://openlibrary.org/works/OL16224122W
+"The History of Rasselas, Prince of Abyssinia","Samuel Johnson, Warren L. Fleischauer, Félix Paknadel, Octavie Belot, James MacAulay",N/A,1759,https://openlibrary.org/works/OL4558936W
+El Club Dumas,Arturo Pérez-Reverte,N/A,1993,https://openlibrary.org/works/OL857568W
+Mythology,Edith Hamilton,N/A,1940,https://openlibrary.org/works/OL5262120W
+"Vite de' più eccellenti pittori, scultori et architettori","Giorgio Vasari, Peter Murray",N/A,1759,https://openlibrary.org/works/OL1298151W
+Captain Underpants and the Attack of the Talking Toilets,Dav Pilkey,N/A,1996,https://openlibrary.org/works/OL8119760W
+Paula,Isabel Allende,N/A,1994,https://openlibrary.org/works/OL1905373W
+Under the Dome,Stephen King,N/A,2009,https://openlibrary.org/works/OL14917748W
+The city and the pillar,Gore Vidal,N/A,1948,https://openlibrary.org/works/OL98031W
+Relato de un náufrago,Gabriel García Márquez,N/A,1970,https://openlibrary.org/works/OL274550W
+The Ocean at the End of the Lane,"Neil Gaiman, Mónica Faerna, Patrick Marcel, Lluís Delgado, Oriol Hernández",N/A,2013,https://openlibrary.org/works/OL16804661W
+The Quiet American,Graham Greene,N/A,1940,https://openlibrary.org/works/OL106081W
+What Katy Did,"Susan Coolidge, Adele Ledyard, Addie Ledyard",N/A,1873,https://openlibrary.org/works/OL5114586W
+Starship Troopers,Robert A. Heinlein,N/A,1959,https://openlibrary.org/works/OL59740W
+Cover Her Face,P. D. James,N/A,1962,https://openlibrary.org/works/OL510872W
+Allegiant,Veronica Roth,N/A,2001,https://openlibrary.org/works/OL16808471W
+L'immoraliste,André Gide,N/A,1902,https://openlibrary.org/works/OL631007W
+The Penelopiad,Margaret Atwood,N/A,2005,https://openlibrary.org/works/OL675737W
+The Greek myths,Robert Graves,N/A,1955,https://openlibrary.org/works/OL5036951W
+Moriæ Encomium,Desiderius Erasmus,N/A,1515,https://openlibrary.org/works/OL679942W
+Into Thin Air,Jon Krakauer,N/A,1996,https://openlibrary.org/works/OL1974548W
+The Marble Faun,Nathaniel Hawthorne,N/A,1840,https://openlibrary.org/works/OL455336W
+The Rape of the Lock,Alexander Pope,N/A,1714,https://openlibrary.org/works/OL79362W
+The Wide Window,"Lemony Snicket, Brett Helquist, Michael Kupperman, Nestor Busquets",N/A,2000,https://openlibrary.org/works/OL15104131W
+The Tale of Peter Rabbit,Beatrix Potter,N/A,1900,https://openlibrary.org/works/OL108735W
+The poetical works of Sir Walter Scott,Sir Walter Scott,N/A,1800,https://openlibrary.org/works/OL863810W
+Martin Chuzzlewit,Charles Dickens,N/A,1800,https://openlibrary.org/works/OL14869242W
+Life of Samuel Johnson,James Boswell,N/A,1776,https://openlibrary.org/works/OL16234621W
+Eaters of the Dead,Michael Crichton,N/A,1976,https://openlibrary.org/works/OL46873W
+The Naked Sun,Isaac Asimov,N/A,1954,https://openlibrary.org/works/OL46398W
+By the Shores of Silver Lake,"Laura Ingalls Wilder, Garth Williams",N/A,1924,https://openlibrary.org/works/OL1719790W
+Institutio Christianae religionis,Jean Calvin,N/A,1536,https://openlibrary.org/works/OL938509W
+Christmas Books (Battle of Life / Chimes / Christmas Carol / Cricket on the Hearth / Haunted Man),Charles Dickens,N/A,1800,https://openlibrary.org/works/OL8721461W
+The advancement of learning,Francis Bacon,N/A,1605,https://openlibrary.org/works/OL15403036W
+The Unfinished Nation,Alan Brinkley,N/A,1993,https://openlibrary.org/works/OL176193W
+The World Is Flat -A Brief History OF THE TWENTY-FIRST CENTURY,Thomas L. Friedman,N/A,2005,https://openlibrary.org/works/OL3740416W
+Plutarchi Vitae parallelae,Plutarch,N/A,1478,https://openlibrary.org/works/OL723358W
+Tale of Despereaux,Kate DiCamillo,N/A,2003,https://openlibrary.org/works/OL468677W
+The mis-education of the Negro,Carter Godwin Woodson,N/A,1933,https://openlibrary.org/works/OL48136W
+Wolves of the Calla,Stephen King,N/A,2003,https://openlibrary.org/works/OL81594W
+The Green Fairy Book (Large Print),"Andrew Lang, Henry Justice Ford",N/A,1892,https://openlibrary.org/works/OL1088797W
+La sociedad del espectáculo,"Guy Debord, Guy Debord, Ron. Adams, Donald Nicholson-Smith, Colectivo Maldeojo",N/A,1967,https://openlibrary.org/works/OL3160238W
+The Black Dahlia,James Ellroy,N/A,1987,https://openlibrary.org/works/OL553754W
+"Speak, Memory",Vladimir Nabokov,N/A,1951,https://openlibrary.org/works/OL627083W
+Pakistan,United States,N/A,1965,https://openlibrary.org/works/OL15292359W
+The English Patient,Michael Ondaatje,N/A,1992,https://openlibrary.org/works/OL53071W
+The dead secret,Wilkie Collins,N/A,1857,https://openlibrary.org/works/OL176087W
+The Pale Horse,Agatha Christie,N/A,1961,https://openlibrary.org/works/OL471919W
+MAIN STREET,Sinclair Lewis,N/A,1920,https://openlibrary.org/works/OL51117W
+The deerslayer,James Fenimore Cooper,N/A,1841,https://openlibrary.org/works/OL77950W
+I am Legend,Richard Matheson,N/A,1954,https://openlibrary.org/works/OL11374287W
+Tales of a Fourth Grade Nothing,Judy Blume,N/A,1972,https://openlibrary.org/works/OL1838382W
+Little Town on the Prairie,"Laura Ingalls Wilder, Garth Williams",N/A,1941,https://openlibrary.org/works/OL1719805W
+The Secret History,Donna Tartt,N/A,1992,https://openlibrary.org/works/OL4321141W
+Sahara,Clive Cussler,N/A,1982,https://openlibrary.org/works/OL84925W
+"The Muqaddimah, an introduction to history","Ibn Khaldūn, عبد الرحمن ابن خلدون Abdel Rahman Ibn Khaldun",N/A,1858,https://openlibrary.org/works/OL1597257W
+The Grand Sophy,Georgette Heyer,N/A,1950,https://openlibrary.org/works/OL4092680W
+Letters to his son,"Philip Dormer Stanhope, 4th Earl of Chesterfield",N/A,1774,https://openlibrary.org/works/OL671958W
+The  French Revolution,Thomas Carlyle,N/A,1837,https://openlibrary.org/works/OL1064769W
+Insomnia,Stephen King,N/A,1994,https://openlibrary.org/works/OL81603W
+The confidential agent,Graham Greene,N/A,1939,https://openlibrary.org/works/OL106076W
+Partners in Crime,Agatha Christie,N/A,1929,https://openlibrary.org/works/OL471928W
+Washington Square,Henry James,N/A,1880,https://openlibrary.org/works/OL276395W
+Il barone rampante,Italo Calvino,N/A,1957,https://openlibrary.org/works/OL15322W
+The Cricket on the Hearth,Charles Dickens,N/A,1846,https://openlibrary.org/works/OL14868783W
+The Damned,Algernon Blackwood,N/A,2002,https://openlibrary.org/works/OL2700643W
+Les Mandarins,Simone de Beauvoir,N/A,1954,https://openlibrary.org/works/OL260381W
+Biology,Neil Alexander Campbell,N/A,1987,https://openlibrary.org/works/OL1983087W
+Mary Poppins,P. L. Travers,N/A,1934,https://openlibrary.org/works/OL262141W
+Complete Big Nate,Lincoln Peirce,N/A,2015,https://openlibrary.org/works/OL26318226W
+La chartreuse de Parme,Stendhal,N/A,1800,https://openlibrary.org/works/OL733285W
+Japanese fairy tales,Yei Theodora Ozaki,N/A,2002,https://openlibrary.org/works/OL19923414W
+Silent Spring,Rachel Carson,N/A,1962,https://openlibrary.org/works/OL1884862W
+Sanditon,Jane Austen,N/A,1925,https://openlibrary.org/works/OL66575W
+The Wee Free Men,"Terry Pratchett, Paul Kidby",N/A,1994,https://openlibrary.org/works/OL453748W
+The Last Days of Hitler,H. R. Trevor-Roper,N/A,1947,https://openlibrary.org/works/OL4147253W
+The Door into Summer,Robert A. Heinlein,N/A,1957,https://openlibrary.org/works/OL59733W
+Longitude,"Dava Sobel, William J. H. Andrewes, Irene Aldasoro Katarain",N/A,1995,https://openlibrary.org/works/OL265465W
+Autobiography,John Stuart Mill,N/A,1873,https://openlibrary.org/works/OL1068072W
+The Shelters of Stone,Jean M. Auel,N/A,2001,https://openlibrary.org/works/OL2746370W
+La ciudad de las bestias,Isabel Allende,N/A,2002,https://openlibrary.org/works/OL1905269W
+Physics for scientists and engineers,"Paul A. Tipler, Gene Mosca",N/A,1990,https://openlibrary.org/works/OL1984422W
+The Third Wheel,Jeff Kinney,N/A,2003,https://openlibrary.org/works/OL16797312W
+Poems,Matthew Arnold,N/A,1853,https://openlibrary.org/works/OL1336796W
+The Magic of Oz,L. Frank Baum,N/A,1919,https://openlibrary.org/works/OL262380W
+Artemis Fowl and the Arctic Incident,Eoin Colfer,N/A,2001,https://openlibrary.org/works/OL5725964W
+Lucky Jim,Kingsley Amis,N/A,1953,https://openlibrary.org/works/OL1863530W
+The Scarlet Plague,Jack London,N/A,1910,https://openlibrary.org/works/OL74485W
+Bleach,Tite Kubo,N/A,2004,https://openlibrary.org/works/OL8756238W
+Indian Fairy Tales,"Joseph Jacobs, John D Batten, Gloria Cardew, Joseph JACOBS, Joseph Jacobs, Jacobs, Ed, Joseph, John Dickson Batten, Joseph Joseph Jacobs",N/A,1892,https://openlibrary.org/works/OL240336W
+Θεαίτητος,Πλάτων,N/A,1861,https://openlibrary.org/works/OL51854W
+A Storm of Swords,George R. R. Martin,N/A,2000,https://openlibrary.org/works/OL257914W
+The Sign of the Beaver,Elizabeth George Speare,N/A,1944,https://openlibrary.org/works/OL4783030W
+Twice-Told Tales,Nathaniel Hawthorne,N/A,1837,https://openlibrary.org/works/OL455489W
+Gerald's Game,Stephen King,N/A,1992,https://openlibrary.org/works/OL81617W
+The Tale of Benjamin Bunny,"Beatrix Potter, Wendy Rasmussen, H.Y. Xiao PhD",N/A,1904,https://openlibrary.org/works/OL22156524W
+Tom's Midnight Garden,Philippa Pearce,N/A,1958,https://openlibrary.org/works/OL2004807W
+Norwegian Wood,村上春樹,N/A,1987,https://openlibrary.org/works/OL2625457W
+Black Cauldron (Chronicles of Prydain,Lloyd Alexander,N/A,1965,https://openlibrary.org/works/OL1966566W
+The magic Faraway Tree,Enid Blyton,N/A,1943,https://openlibrary.org/works/OL1948587W
+The Franchise Affair (Inspector Alan Grant #3),Josephine Tey,N/A,1948,https://openlibrary.org/works/OL80946W
+Dei delitte e delle pene,Cesare Beccaria,N/A,1764,https://openlibrary.org/works/OL1223677W
+Night Over Water,"Ken Follett, K. Follett",N/A,1981,https://openlibrary.org/works/OL1914085W
+Ramona and Her Father,Beverly Cleary,N/A,1977,https://openlibrary.org/works/OL151989W
+Disgrace,J. M. Coetzee,N/A,1999,https://openlibrary.org/works/OL500451W
+The Complete Short Stories of Ernest Hemingway,"Ernest Hemingway, Ernest Hemingway",N/A,1930,https://openlibrary.org/works/OL15332376W
+Into the Wild,Erin Hunter,N/A,2003,https://openlibrary.org/works/OL265501W
+Mrs. Frisby and the Rats of Nimh,"Robert C. O'Brien, Zena Bernstein",N/A,1970,https://openlibrary.org/works/OL5092623W
+The Passage,Justin Cronin,N/A,2010,https://openlibrary.org/works/OL15168588W
+The Guernsey Literary and Potato Peel Pie Society,"Mary Ann Shaffer, Annie Barrows, Mary Ann Shaffe",N/A,2008,https://openlibrary.org/works/OL9334371W
+Μένων,Πλάτων,N/A,1869,https://openlibrary.org/works/OL51940W
+Unfinished Tales of Númenor and Middle-earth,J.R.R. Tolkien,N/A,1980,https://openlibrary.org/works/OL27466W
+Novels (The Call of the Wild / White Fang),Jack London,N/A,1962,https://openlibrary.org/works/OL144709W
+Actes and monuments,John Foxe,N/A,1563,https://openlibrary.org/works/OL2290422W
+Five Run Away Together,Enid Blyton,N/A,1942,https://openlibrary.org/works/OL1948504W
+Mansfield Park,Jane Austen,N/A,1814,https://openlibrary.org/works/OL66530W
+Silas Marner,George Eliot,N/A,1860,https://openlibrary.org/works/OL20874W
+Otherwise Known as Sheila the Great,Judy Blume,N/A,1972,https://openlibrary.org/works/OL1838365W
+Split Second,David Baldacci,N/A,2003,https://openlibrary.org/works/OL41246W
+Mostly Harmless,Douglas Adams,N/A,1991,https://openlibrary.org/works/OL2163638W
+The ARRL handbook for the radio amateur,American Radio Relay League (ARRL),N/A,1926,https://openlibrary.org/works/OL5049432W
+The Winter of Our Discontent,John Steinbeck,N/A,1961,https://openlibrary.org/works/OL23190W
+The Wisdom of Father Brown,Gilbert Keith Chesterton,N/A,1913,https://openlibrary.org/works/OL76483W
+The schoolmasters assistant,"Thomas Dilworth, Moses Browne, William Deane, Robert Patterson",N/A,1744,https://openlibrary.org/works/OL1651332W
+What's wrong with the world,"Gilbert Keith Chesterton, CrossReach Publications",N/A,1910,https://openlibrary.org/works/OL76479W
+Doce cuentos peregrinos,Gabriel García Márquez,N/A,1992,https://openlibrary.org/works/OL274515W
+Night and Day,Virginia Woolf,N/A,1919,https://openlibrary.org/works/OL39571W
+The Pathfinder,James Fenimore Cooper,N/A,1800,https://openlibrary.org/works/OL78009W
+The Big Bad Wolf,James Patterson,N/A,2001,https://openlibrary.org/works/OL167179W
+Dreamcatcher,Stephen King,N/A,2001,https://openlibrary.org/works/OL81598W
+Hearts in Atlantis,Stephen King,N/A,1998,https://openlibrary.org/works/OL81624W
+The Silver Sword,Ian Serraillier,N/A,1956,https://openlibrary.org/works/OL4628121W
+Because of Winn-Dixie,Kate DiCamillo,N/A,2000,https://openlibrary.org/works/OL468658W
+Desperation,Stephen King,N/A,1996,https://openlibrary.org/works/OL81611W
+Frederick,Leo Lionni,N/A,1963,https://openlibrary.org/works/OL2162573W
+The Endless Steppe,Esther Rudomin Hautzig,N/A,1968,https://openlibrary.org/works/OL270319W
+From a Buick 8,Stephen King,N/A,2002,https://openlibrary.org/works/OL81586W
+Principles of internal medicine,"Tinsley Randolph Harrison, Kurt J. Isselbacher, Eugene Braunwald, T. R. Harrison, Robert G. Petersdorf, Joseph B. Martin, Annie Ernaux, Marc Marie, Alison L. Strayer, Anthony S. Fauci, Jean D. Wilson MD, Dennis L. Kasper, Stephen L. Hauser, Dan L. Longo, J. Larry Jameson, Joseph Loscalzo, Richard M. Stone, Stephen Hauser, Jean D. Wilson, Richard K. Root, J. Jameson, Cynthia Brown, Charles M. Wiener, Robert Groysman, Groysman",N/A,1950,https://openlibrary.org/works/OL280577W
+Software Engineering,"Roger S. Pressman, Bruce Maxim",N/A,1982,https://openlibrary.org/works/OL284009W
+A short history of nearly everything,Bill Bryson,N/A,2003,https://openlibrary.org/works/OL74128W
+The Gods Themselves,Isaac Asimov,N/A,1972,https://openlibrary.org/works/OL46395W
+"Over Sea, Under Stone (The Dark Is Rising #1)",Susan Cooper,N/A,1965,https://openlibrary.org/works/OL894247W
+The water-witch,James Fenimore Cooper,N/A,1830,https://openlibrary.org/works/OL78052W
+The Crying of Lot 49,Thomas Pynchon,N/A,1965,https://openlibrary.org/works/OL2636665W
+De l'esprit des lois,Charles-Louis de Secondat baron de La Brède et de Montesquieu,N/A,1748,https://openlibrary.org/works/OL453554W
+The Internet for Dummies,"John R. Levine, Carol Baroudi, Margaret Levine Young, Arnold Reinhold, Hy Bender, Geoff Ebbs",N/A,1993,https://openlibrary.org/works/OL57786W
+The Poison Belt,Arthur Conan Doyle,N/A,1913,https://openlibrary.org/works/OL262596W
+Captain Underpants and the Invasion of the Incredibly Naughty Cafeteria Ladies from Outer Space,Dav Pilkey,N/A,1999,https://openlibrary.org/works/OL8119758W
+Titus Andronicus,William Shakespeare,N/A,1600,https://openlibrary.org/works/OL362675W
+"Peau Noire, Masques Blancs","Frantz Fanon, Richard Philcox, Anthony Appiah",N/A,1952,https://openlibrary.org/works/OL1323771W
+The Spy Who Came in from the Cold,John le Carré,N/A,1963,https://openlibrary.org/works/OL15723140W
+The Toll-Gate,Georgette Heyer,N/A,1954,https://openlibrary.org/works/OL4092608W
+The Odessa file,"Frederick Forsyth, Frederick Davidson",N/A,1842,https://openlibrary.org/works/OL15411113W
+Old School,Jeff Kinney,N/A,1997,https://openlibrary.org/works/OL17267509W
+The Miracle Worker,William Gibson,N/A,1956,https://openlibrary.org/works/OL261558W
+Going Solo,Roald Dahl,N/A,1986,https://openlibrary.org/works/OL45875W
+The Alienist,Caleb Carr,N/A,1994,https://openlibrary.org/works/OL2671485W
+Anarchism and Other Essays,Emma Goldman,N/A,1910,https://openlibrary.org/works/OL2983646W
+The Sum of All Fears,Tom Clancy,N/A,1991,https://openlibrary.org/works/OL448878W
+Under the Lilacs,Louisa May Alcott,N/A,1878,https://openlibrary.org/works/OL30065W
+The Very Busy Spider,Eric Carle,N/A,1984,https://openlibrary.org/works/OL52975W
+The Ugly Truth,Jeff Kinney,N/A,2001,https://openlibrary.org/works/OL15192743W
+Artemis Fowl. The Opal Deception,"Eoin Colfer, Adrian Dunbar",N/A,2005,https://openlibrary.org/works/OL5725975W
+Sula,Toni Morrison,N/A,1973,https://openlibrary.org/works/OL50567W
+When Hitler stole Pink Rabbit,Judith Kerr,N/A,1971,https://openlibrary.org/works/OL1742390W
+Authority and the Individual,Bertrand Russell,N/A,1949,https://openlibrary.org/works/OL1088583W
+The Return of Tarzan,Edgar Rice Burroughs,N/A,1915,https://openlibrary.org/works/OL1418249W
+The Happy Prince and other tales,Oscar Wilde,N/A,1888,https://openlibrary.org/works/OL14877874W
+The Broker,John Grisham,N/A,2005,https://openlibrary.org/works/OL76968W
+Seta,Alessandro Baricco,N/A,1920,https://openlibrary.org/works/OL876504W
+College Algebra,Ron Larson,N/A,1900,https://openlibrary.org/works/OL7943062W
+Understanding Media,"Marshall McLuhan, Marshal McLuhan",N/A,1964,https://openlibrary.org/works/OL871783W
+Maurice,E. M. Forster,N/A,1971,https://openlibrary.org/works/OL88877W
+Watchers,Dean Koontz,N/A,1987,https://openlibrary.org/works/OL263297W
+Arabella,Georgette Heyer,N/A,1949,https://openlibrary.org/works/OL4092683W
+The Audacity of Hope,"Barack Obama, Erwin Dorado, Claudia Casanova, Esther Roig Giménez",N/A,2006,https://openlibrary.org/works/OL3246392W
+Wild Swans,Jung Chang,N/A,1991,https://openlibrary.org/works/OL15845961W
+Junky,"William S. Burroughs, Oliver Harris",N/A,1953,https://openlibrary.org/works/OL258131W
+Three Lives,Gertrude Stein,N/A,1909,https://openlibrary.org/works/OL35383W
+Ramona and Her Mother,Beverly Cleary,N/A,1979,https://openlibrary.org/works/OL151961W
+Wrecking Ball,Jeff Kinney,N/A,2019,https://openlibrary.org/works/OL20465177W
+Romeo and Juliet,William Shakespeare,N/A,1936,https://openlibrary.org/works/OL362026W
+The Wonderful Story of Henry Sugar and Six More,Roald Dahl,N/A,1977,https://openlibrary.org/works/OL45864W
+Dreams from My Father,Barack Obama,N/A,1995,https://openlibrary.org/works/OL3246382W
+"1900, or, The last president",Ingersoll Lockwood,N/A,1896,https://openlibrary.org/works/OL11449061W
+Le pont de la rivière kwaï,Pierre Boulle,N/A,1952,https://openlibrary.org/works/OL1319413W
+The New Machiavelli,H. G. Wells,N/A,1900,https://openlibrary.org/works/OL52263W
+Frank Lloyd Wright,Frank Lloyd Wright,N/A,1900,https://openlibrary.org/works/OL961860W
+What is history?,"E. H. Carr, E. Carr, R. Evans",N/A,1961,https://openlibrary.org/works/OL1170598W
+History of art,"H. W. Janson, H.W Janson, H. W Janson, H. W. Janson, Horst Woldemar JANSON, Anthony F. Janson, H. W. Janson",N/A,1962,https://openlibrary.org/works/OL1719867W
+The Monk,Matthew Gregory Lewis,N/A,1794,https://openlibrary.org/works/OL15220454W
+The House on Mango Street,Sandra Cisneros,N/A,1983,https://openlibrary.org/works/OL3243765W
+La Celestina,Fernando de Rojas,N/A,1899,https://openlibrary.org/works/OL938934W
+Principles of corporate finance,"Richard A. Brealey, Richard Brealey, David Brealey, Richard Brealey, Brealey Richard, Richard A Brealey, Stewart C Myers, Franklin Allen, BREALEY, Pitabas Mohanty, Richard Brealey and Stewart Myers and Franklin Allen",N/A,1981,https://openlibrary.org/works/OL72078W
+The Great Hunt (The Wheel of Time Book 2),Robert Jordan,N/A,1990,https://openlibrary.org/works/OL7924135W
+The House on the Borderland,William Hope Hodgson,N/A,1946,https://openlibrary.org/works/OL810402W
+A Distant Mirror,Barbara Tuchman,N/A,1600,https://openlibrary.org/works/OL3378547W
+"Thuvia, Maid of Mars","Edgar Rice Burroughs, Craig Trahan, Eric King, J. Allen St. John",N/A,1916,https://openlibrary.org/works/OL1418128W
+My side of the mountain,Jean Craighead George,N/A,1959,https://openlibrary.org/works/OL111900W
+Equal Rites,Terry Pratchett,N/A,1987,https://openlibrary.org/works/OL453670W
+From slavery to freedom,"John Hope Franklin, Alfred A. Moss Jr., Evelyn Brooks Higginbotham",N/A,1947,https://openlibrary.org/works/OL55887W
+Stormbreaker,Anthony Horowitz,N/A,2000,https://openlibrary.org/works/OL80763W
+The way of all flesh,Samuel Butler,N/A,1900,https://openlibrary.org/works/OL22372W
+Brisingr,Christopher Paolini,N/A,1998,https://openlibrary.org/works/OL5819884W
+Baby Einstein,"Julie Aigner-Clark, Nadeem Zaidi",N/A,2001,https://openlibrary.org/works/OL8571036W
+Herfsttij der Middeleeuwen,Johan Huizinga,N/A,1919,https://openlibrary.org/works/OL1141875W
+Πρωταγόρας,Πλάτων,N/A,1828,https://openlibrary.org/works/OL51938W
+The Kreutzer sonata and other stories,Лев Толстой,N/A,1887,https://openlibrary.org/works/OL15088382W
+Plain tales from the hills,Rudyard Kipling,N/A,1888,https://openlibrary.org/works/OL20170W
+Tropic of Capricorn,Henry Miller,N/A,1939,https://openlibrary.org/works/OL261868W
+The Satanic Verses,Salman Rushdie,N/A,1988,https://openlibrary.org/works/OL457175W
+The Trumpet of the Swan,E. B. White,N/A,1970,https://openlibrary.org/works/OL483387W
+Der Einzige und sein Eigentum,Max Stirner,N/A,1845,https://openlibrary.org/works/OL1445824W
+Evgeniĭ Onegin,Александр Сергеевич Пушкин,N/A,1833,https://openlibrary.org/works/OL623499W
+Music,Roger Kamien,N/A,1976,https://openlibrary.org/works/OL2770497W
+Doctor No,Ian Fleming,N/A,1958,https://openlibrary.org/works/OL85736W
+Double Down,Jeff Kinney,N/A,2007,https://openlibrary.org/works/OL17603394W
+Caddie Woodlawn,Carol Ryrie Brink,N/A,1935,https://openlibrary.org/works/OL265984W
+Two years before the mast,Richard Henry Dana,N/A,1000,https://openlibrary.org/works/OL1815550W
+The C Programming Language,"Brian W. Kernighan, Dennis MacAlistair Ritchie",N/A,1978,https://openlibrary.org/works/OL4617640W
+The Tales of Beedle the Bard,J. K. Rowling,N/A,2008,https://openlibrary.org/works/OL13716951W
+Raise the Titanic!,Clive Cussler,N/A,1976,https://openlibrary.org/works/OL84918W
+"Capitalism, Socialism and Democracy","Joseph Alois Schumpeter, Gaël Fain, Roberto Ramos Fontecoba",N/A,1942,https://openlibrary.org/works/OL1295326W
+Sociology,Richard T. Schaefer,N/A,1979,https://openlibrary.org/works/OL2005734W
+A little princess,Bob Blaisdell,N/A,1905,https://openlibrary.org/works/OL15040856W
+The Structure of Scientific Revolutions,"Thomas S. Kuhn, Dennis Holland",N/A,1955,https://openlibrary.org/works/OL3259254W
+The house without a key,Earl Derr Biggers,N/A,1925,https://openlibrary.org/works/OL6438827W
+Publication Manual of the American Psycological Association,"American Psychological Association., American Psychological Association, AMERICAN PSYCHOLOGICAL ASSOCIATION, 6th Edition Publication Manual of the American Psychological Association, APA (2010)",N/A,1952,https://openlibrary.org/works/OL3282884W
+Wizard's First Rule,Terry Goodkind,N/A,1994,https://openlibrary.org/works/OL2010436W
+Odyssey,Όμηρος,N/A,1980,https://openlibrary.org/works/OL26784440W
+The Curious Case of Benjamin Button,F. Scott Fitzgerald,N/A,2007,https://openlibrary.org/works/OL468384W
+The Currents of Space,Isaac Asimov,N/A,1952,https://openlibrary.org/works/OL46385W
+Mémoires d'une jeune fille rangée,Simone de Beauvoir,N/A,1900,https://openlibrary.org/works/OL260382W
+The history of the Peleponnesian war,"Thucydides, Pat Bottino",N/A,1545,https://openlibrary.org/works/OL762880W
+The great controversy,"Ellen Gould Harmon White, E. G. White, Ellen G White, Ellen White, Ellen G. White, E.G. White, Ellen Gould Harmon White, White E.G, Ellen G. White, White, E. G., Ellen G. WHITE, Pacific Press Publishing Associaton",N/A,1858,https://openlibrary.org/works/OL1887655W
+The Death and Life of Great American Cities,Jane Jacobs,N/A,1961,https://openlibrary.org/works/OL93641W
+Rose in Bloom,"Louisa May Alcott, Harriet Roosevelt Richards",N/A,1876,https://openlibrary.org/works/OL30020W
+Nightwood,Djuna Barnes,N/A,1936,https://openlibrary.org/works/OL505583W
+Poems,Elizabeth Barrett Browning,N/A,1844,https://openlibrary.org/works/OL1198483W
+The Electric Kool-Aid Acid Test,Tom Wolfe,N/A,1968,https://openlibrary.org/works/OL1925362W
+The Miserable Mill,Lemony Snicket,N/A,2000,https://openlibrary.org/works/OL15104047W
+Effective Executive,"Peter F. Drucker, Joseph A. Maciariello, Jim Collins, Tim Andres Pabon, Zachary First",N/A,1967,https://openlibrary.org/works/OL272920W
+The story of art,E. H. Gombrich,N/A,1950,https://openlibrary.org/works/OL686193W
+C. Iulii Caesaris Commentarii de bello gallico,"Gaius Julius Caesar, Marieluise Deißmann",N/A,1570,https://openlibrary.org/works/OL10306940W
+21st Century Astronomy,"Jeffrey S. Hester, David Burstein, George Blumenthal, Ronald Greeley, Jeff Hester, Bradford Smith, Howard Voss, Gary Wegner",N/A,2002,https://openlibrary.org/works/OL21725900W
+How to Stop Worrying and Start Living,"Dale Carnegie, Kaneiji Dale",N/A,1936,https://openlibrary.org/works/OL1063338W
+The Book Of Three,"Alexander, Lloyd Alexander",N/A,1964,https://openlibrary.org/works/OL270887W
+Children of Dune,Frank Herbert,N/A,1976,https://openlibrary.org/works/OL893516W
+Evangeline,Henry Wadsworth Longfellow,N/A,1847,https://openlibrary.org/works/OL495761W
+"The Stars, Like Dust",Isaac Asimov,N/A,1951,https://openlibrary.org/works/OL46399W
+If There Be Thorns,V. C. Andrews,N/A,1981,https://openlibrary.org/works/OL134891W
+The Watsons go to Birmingham--1963,"Christopher Paul Curtis, Reginald André Jackson, Eida de la Vega",N/A,1963,https://openlibrary.org/works/OL115601W
+L'Éducation sentimentale,Gustave Flaubert,N/A,1898,https://openlibrary.org/works/OL893802W
+The Amazing Maurice and His Educated Rodents,"Terry Pratchett, Javier Calvo Perales",N/A,2001,https://openlibrary.org/works/OL453885W
+The discovery of India,Jawaharlal Nehru,N/A,1946,https://openlibrary.org/works/OL296039W
+The Kitchen God's Wife,Amy Tan,N/A,1991,https://openlibrary.org/works/OL15821869W
+Cosmos,Carl Sagan,N/A,1980,https://openlibrary.org/works/OL15829966W
+The Five Love Languages,Gary D. Chapman,N/A,1992,https://openlibrary.org/works/OL1680319W
+Corduroy,Don Freeman,N/A,1968,https://openlibrary.org/works/OL4114525W
+Osudy dobrého vojáka Švejka za světové války,Jaroslav Hašek,N/A,1926,https://openlibrary.org/works/OL835204W
+"The art of cookery, made plain and easy",Hannah Glasse,N/A,1747,https://openlibrary.org/works/OL1646026W
+A Case of Need,Michael Crichton,N/A,1968,https://openlibrary.org/works/OL46903W
+Gedichte,Johann Wolfgang von Goethe,N/A,1700,https://openlibrary.org/works/OL15369501W
+Ringworld,Larry Niven,N/A,1970,https://openlibrary.org/works/OL510405W
+Cymbeline,William Shakespeare,N/A,1734,https://openlibrary.org/works/OL258656W
+A People's History of the United States,"Howard Zinn, Howard Zinn",N/A,1980,https://openlibrary.org/works/OL50283W
+The Rise and Fall of the Third Reich,William L. Shirer,N/A,1901,https://openlibrary.org/works/OL47181W
+Rubaiyat of Omar Khayyam,Omar Khayyam,N/A,1859,https://openlibrary.org/works/OL998027W
+Struwwelpeter,Heinrich Hoffmann,N/A,1865,https://openlibrary.org/works/OL1115809W
+A View from the Bridge,Arthur Miller,N/A,1955,https://openlibrary.org/works/OL66345W
+The Economic Consequences of the Peace (Twentieth-Century Classics),"John Maynard Keynes, Jens Hölscher, Matthias Klaes, Anonymous",N/A,1919,https://openlibrary.org/works/OL35914W
+The Cyberiad,Stanisław Lem,N/A,1965,https://openlibrary.org/works/OL2683553W
+The Fixer,Bernard Malamud,N/A,1901,https://openlibrary.org/works/OL1937854W
+Civilization in the West,"Mark A. Kishlansky, Patrick J. Geary, Patricia O'Brien",N/A,1991,https://openlibrary.org/works/OL2047705W
+King Henry IV. Part 2,William Shakespeare,N/A,1600,https://openlibrary.org/works/OL362697W
+A Child's History of England,Charles Dickens,N/A,1800,https://openlibrary.org/works/OL9250413W
+I Malavoglia,Giovanni Verga,N/A,1881,https://openlibrary.org/works/OL479183W
+Sourcery,Terry Pratchett,N/A,1988,https://openlibrary.org/works/OL453659W
+Lords and Ladies,"Terry Pratchett, Nigel Planer, Tony Robinson",N/A,1992,https://openlibrary.org/works/OL453787W
+Calculus,"Howard Anton, Howard A. Anton, Irl Bivens, Stephen Davis, Bernard V. Zandy, Jonathan J. White",N/A,1980,https://openlibrary.org/works/OL485863W
+Max Havelaar of de koffijveilingen der Nederlansche handelmaatschappij,Multatuli,N/A,1868,https://openlibrary.org/works/OL658280W
+Short stories,Franz Kafka,N/A,1946,https://openlibrary.org/works/OL498623W
+Danny and the Dinosaur,Syd Hoff,N/A,1958,https://openlibrary.org/works/OL106091W
+The long ships,Frans Gunnar Bengtsson,N/A,1943,https://openlibrary.org/works/OL257663W
+Barbie Horse Trouble Barbie Look Look,Golden Books,N/A,1921,https://openlibrary.org/works/OL8043761W
+Financial audit,United States. General Accounting Office,N/A,1975,https://openlibrary.org/works/OL10733909W
+Triple,Ken Follett,N/A,1979,https://openlibrary.org/works/OL1914091W
+My father's dragon,Ruth Stiles Gannett,N/A,1948,https://openlibrary.org/works/OL2688555W
+The house by the church-yard,Sheridan Le Fanu,N/A,1863,https://openlibrary.org/works/OL2895540W
+Jonathan Strange and Mr. Norrell,Susanna Clarke,N/A,2001,https://openlibrary.org/works/OL5703422W
+The house of the four winds,John Buchan,N/A,1935,https://openlibrary.org/works/OL76579W
+2nd Chance,"James Patterson, Andrew Gross",N/A,2002,https://openlibrary.org/works/OL167157W
+Another Country,"James Baldwin, James Bladwin, J. Baldwin, Stryker Flint, James Baldwin - undifferentiated",N/A,1962,https://openlibrary.org/works/OL228715W
+The works of Hubert Howe Bancroft,Hubert Howe Bancroft,N/A,1882,https://openlibrary.org/works/OL3421434W
+State of Fear,Michael Crichton,N/A,2004,https://openlibrary.org/works/OL46914W
+"Can't You Sleep, Little Bear?","Martin Waddell, Barbara Firth, Virginia Miller",N/A,1988,https://openlibrary.org/works/OL114207W
+Las venas abiertas de América Latina,"Eduardo Galeano, Galeano, Eduardo Galeano, Cedric Belfrage",N/A,1971,https://openlibrary.org/works/OL698173W
+The Forever War,Joe Haldeman,N/A,1974,https://openlibrary.org/works/OL271163W
+Dance Upon the Air,Nora Roberts,N/A,1902,https://openlibrary.org/works/OL111597W
+Four,Veronica Roth,N/A,2001,https://openlibrary.org/works/OL16825084W
+Ich und du,Martin Buber,N/A,1922,https://openlibrary.org/works/OL12337W
+The Subtle Art of Not Giving a F*ck,Mark Manson,N/A,2016,https://openlibrary.org/works/OL17590212W
+Little Bear's Visit,Else Holmelund Minarik,N/A,1961,https://openlibrary.org/works/OL2568814W
+By the Pricking of My Thumbs,Agatha Christie,N/A,1968,https://openlibrary.org/works/OL471619W
+The Poisonwood Bible,"Barbara Kingsolver, Dean Robertson",N/A,1998,https://openlibrary.org/works/OL1846846W
+The ruby in the smoke (Sally Lockhart #1),Philip Pullman,N/A,1985,https://openlibrary.org/works/OL29026W
+Pebble in the Sky,Isaac Asimov,N/A,1950,https://openlibrary.org/works/OL46402W
+These Happy Golden Years,"Laura Ingalls Wilder, Garth Williams",N/A,1943,https://openlibrary.org/works/OL1719702W
+The Goldfinch,"Donna Tartt, Katia Benovich",N/A,2013,https://openlibrary.org/works/OL16809803W
+Film art,"David Bordwell, Kristin Thompson, D. & THOMPSON BORDWELL, David Bordwell",N/A,1979,https://openlibrary.org/works/OL10665037W
+Where Are the Children?,Mary Higgins Clark,N/A,1975,https://openlibrary.org/works/OL12992W
+Hannibal,Thomas Harris,N/A,1999,https://openlibrary.org/works/OL23478W
+Dombey and Son,"Charles Dickens, Ian Perkin, A. Willis, Forster, John, Jason Lee",N/A,1800,https://openlibrary.org/works/OL14868861W
+The Logic of Scientific Discovery,Karl Popper,N/A,1935,https://openlibrary.org/works/OL1984582W
+The Polar Express Gift Set,Chris Van Allsburg,N/A,1985,https://openlibrary.org/works/OL3743751W
+The Fall of the House of Usher,Edgar Allan Poe,N/A,1839,https://openlibrary.org/works/OL41078W
+Foundation and Earth,Isaac Asimov,N/A,1986,https://openlibrary.org/works/OL46347W
+El Señor Presidente,"Miguel Ángel Asturias, Miguel Asturias, David Unger, Mario Vargas Llosa, Gerald Martin",N/A,1948,https://openlibrary.org/works/OL938588W
+Small Gods,Terry Pratchett,N/A,1992,https://openlibrary.org/works/OL453697W
+The story of my life,Helen Keller,N/A,1903,https://openlibrary.org/works/OL53604W
+Art history,"Marilyn Stokstad, Margaret A. Oppenheimer",N/A,1995,https://openlibrary.org/works/OL29921W
+De bello judaico,Flavius Josephus,N/A,1481,https://openlibrary.org/works/OL10464115W
+How the Grinch Stole Christmas!,"Dr. Seuss, Rik Mayall",N/A,1957,https://openlibrary.org/works/OL261169W
+The Man Without a Country,"Edward Everett Hale, Florence Maria Miller",N/A,1865,https://openlibrary.org/works/OL2339752W
+Along Came a Spider,James Patterson,N/A,1993,https://openlibrary.org/works/OL167178W
+Forward the Foundation,Isaac Asimov,N/A,1993,https://openlibrary.org/works/OL46299W
+The fire next time,James Baldwin,N/A,1962,https://openlibrary.org/works/OL2683364W
+The Complete Jungle Book,Rudyard Kipling,N/A,1895,https://openlibrary.org/works/OL20102W
+Biology,"Kenneth R. Miller, Joseph S. Levine, Prentice-Hall, inc., Joseph Levine",N/A,1990,https://openlibrary.org/works/OL277185W
+Contact,Carl Sagan,N/A,1985,https://openlibrary.org/works/OL2950903W
+Neverwhere,Neil Gaiman,N/A,1996,https://openlibrary.org/works/OL679333W
+Réquiem por un campesino español,Ramón J. Sender,N/A,1960,https://openlibrary.org/works/OL913741W
+My Sister's Keeper,Jodi Picoult,N/A,2004,https://openlibrary.org/works/OL891923W
+Cider with Rosie,Laurie Lee,N/A,1959,https://openlibrary.org/works/OL1209517W
+A Hat Full of Sky,"Terry Pratchett, Paul Kidby, Terry Pratchett",N/A,2004,https://openlibrary.org/works/OL453737W
+Sister Carrie,Theodore Dreiser,N/A,1900,https://openlibrary.org/works/OL100203W
+A Wind in the Door (Time Quintet #2,Madeleine L'Engle,N/A,1973,https://openlibrary.org/works/OL41494W
+Song of Susannah,Stephen King,N/A,1999,https://openlibrary.org/works/OL149200W
+The magic of believing,"Claude M. Bristol, Site Burui, Claudie Bristol",N/A,1948,https://openlibrary.org/works/OL120672W
+Friday's Child,Georgette Heyer,N/A,1944,https://openlibrary.org/works/OL4092675W
+Women who run with the wolves,"Clarissa Pinkola Estés, Clarissa Pinkola Estes, Clarissa Pinkola Estés, ANTONIA MENINI PAGES, María Antonia Menini Pagès, Maria Antonia Menini",N/A,1982,https://openlibrary.org/works/OL2960639W
+In the days of the comet,H. G. Wells,N/A,1906,https://openlibrary.org/works/OL52252W
+Freedom at Midnight,"Dominique Lapierre, Larry Collins",N/A,1975,https://openlibrary.org/works/OL1751683W
+Fundamentals Of Electricity And Magnetism,McGraw-Hill,N/A,2001,https://openlibrary.org/works/OL14996328W
+Nutrition,"Lori A. Smolin, Smolin",N/A,1994,https://openlibrary.org/works/OL3000098W
+Sabriel,Garth Nix,N/A,1995,https://openlibrary.org/works/OL2628761W
+The Plot Against America,Philip Roth,N/A,2004,https://openlibrary.org/works/OL74664W
+The Perks of Being a Wallflower,"Stephen Chbosky, Stephen Chbosky",N/A,1999,https://openlibrary.org/works/OL875437W
+The Tiny Seed,Eric Carle,N/A,1970,https://openlibrary.org/works/OL52982W
+Call It Courage,Armstrong Sperry,N/A,1940,https://openlibrary.org/works/OL4785050W
+Steve Jobs,Walter Isaacson,N/A,2011,https://openlibrary.org/works/OL16085155W
+The Snail and the Whale,Julia Donaldson,N/A,2001,https://openlibrary.org/works/OL1938304W
+Heaven,V. C. Andrews,N/A,1985,https://openlibrary.org/works/OL134889W
+The Appeal,John Grisham,N/A,2008,https://openlibrary.org/works/OL76959W
+The Beetle,"Richard Marsh, Satomi Sugita",N/A,1897,https://openlibrary.org/works/OL827326W
+Meditations,Marcus Aurelius,N/A,2004,https://openlibrary.org/works/OL26581800W
+The Circular Staircase,Mary Roberts Rinehart,N/A,1908,https://openlibrary.org/works/OL137396W
+The Final Empire,Brandon Sanderson,N/A,2001,https://openlibrary.org/works/OL5738148W
+Elric of Melniboné,Michael Moorcock,N/A,1972,https://openlibrary.org/works/OL2697666W
+Rosemary's Baby,Ira Levin,N/A,1900,https://openlibrary.org/works/OL28322W
+Winnie-the-Pooh / The House at Pooh Corner,A. A. Milne,N/A,1926,https://openlibrary.org/works/OL476737W
+The Throne of Fire,Rick Riordan,N/A,2011,https://openlibrary.org/works/OL15946464W
+The Swiss Family Robinson,Johann David Wyss,N/A,1979,https://openlibrary.org/works/OL20173104W
+Congo,Michael Crichton,N/A,1980,https://openlibrary.org/works/OL46913W
+King Rat,James Clavell,N/A,1950,https://openlibrary.org/works/OL2918736W
+Glinda of Oz,L. Frank Baum,N/A,1920,https://openlibrary.org/works/OL262391W
+Jack & Jill,James Patterson,N/A,1714,https://openlibrary.org/works/OL167185W
+Gregor the Overlander,Suzanne Collins,N/A,2003,https://openlibrary.org/works/OL5735348W
+Wyrd Sisters,Terry Pratchett,N/A,1988,https://openlibrary.org/works/OL453660W
+Oryx and Crake,Margaret Atwood,N/A,2002,https://openlibrary.org/works/OL675722W
+Calculus,Ron Larson,N/A,1988,https://openlibrary.org/works/OL15859946W
+Hard Luck,Jeff Kinney,N/A,2001,https://openlibrary.org/works/OL16810620W
+Girl with a Pearl Earring,Tracy Chevalier,N/A,1999,https://openlibrary.org/works/OL456231W
+The Vampire Armand,Anne Rice,N/A,1998,https://openlibrary.org/works/OL77832W
+Herr der Diebe,Cornelia Funke,N/A,2000,https://openlibrary.org/works/OL941674W
+The True Story of the Three Little Pigs,Jon Scieszka,N/A,1989,https://openlibrary.org/works/OL2940317W
+Hour Game,David Baldacci,N/A,2004,https://openlibrary.org/works/OL41245W
+A Man of the People,"Chinua Achebe, Chinua Achebe",N/A,1966,https://openlibrary.org/works/OL891787W
+The Witching Hour,Anne Rice,N/A,1990,https://openlibrary.org/works/OL77817W
+Bunnicula,"Deborah Howe, James Howe",N/A,1979,https://openlibrary.org/works/OL3464570W
+In the Heart of the Sea,Nathaniel Philbrick,N/A,2000,https://openlibrary.org/works/OL800722W
+Wives and daughters,"Elizabeth Cleghorn Gaskell, Gaskell, Mrs., Ward, A. W., Gaskell",N/A,1866,https://openlibrary.org/works/OL1103200W
+The Hill of Dreams,Arthur Machen,N/A,1907,https://openlibrary.org/works/OL3389031W
+Danse Macabre,Stephen King,N/A,1980,https://openlibrary.org/works/OL81605W
+Moonraker,Ian Fleming,N/A,1955,https://openlibrary.org/works/OL85743W
+El Dorado,"Emmuska Orczy, Baroness Orczy",N/A,1913,https://openlibrary.org/works/OL8722827W
+The White Dragon,Anne McCaffrey,N/A,1978,https://openlibrary.org/works/OL73384W
+Ethica,"Benedictus de Spinoza, Wolfgang Bartuschat",N/A,1883,https://openlibrary.org/works/OL35989W
+The Sword of Shannara,Terry Brooks,N/A,1976,https://openlibrary.org/works/OL5683445W
+Детство; Отрочество; Юность,"Tolstoy, Leo, graf, 1828-1910",N/A,1862,https://openlibrary.org/works/OL15698346W
+The Graveyard Book,Neil Gaiman,N/A,2008,https://openlibrary.org/works/OL679348W
+The Angel of Terror,Edgar Wallace,N/A,1923,https://openlibrary.org/works/OL1518053W
+The Robots of Dawn,Isaac Asimov,N/A,1983,https://openlibrary.org/works/OL46377W
+The works of Horace,Horace,N/A,1681,https://openlibrary.org/works/OL88218W
+The Grouchy Ladybug,Eric Carle,N/A,1977,https://openlibrary.org/works/OL52966W
+Vingt ans apres̀,Alexandre Dumas,N/A,1800,https://openlibrary.org/works/OL36462W
+The Lathe of Heaven,Ursula K. Le Guin,N/A,1971,https://openlibrary.org/works/OL59858W
+A primer of Freudian psychology,Calvin S. Hall,N/A,1954,https://openlibrary.org/works/OL1941879W
+The Wave,Todd Strasser,N/A,1981,https://openlibrary.org/works/OL999053W
+The Human Condition,Hannah Arendt,N/A,1958,https://openlibrary.org/works/OL10460638W
+That hideous strength,C.S. Lewis,N/A,1945,https://openlibrary.org/works/OL71165W
+Commentaries on the laws of England,Sir William Blackstone,N/A,1721,https://openlibrary.org/works/OL2417578W
+The Intelligent Investor,"Benjamin Graham, Jason Zweig",N/A,1949,https://openlibrary.org/works/OL273184W
+The Nightingale,Kristin Hannah,N/A,2000,https://openlibrary.org/works/OL17116910W
+A Dance With Dragons,George R. R. Martin,N/A,2008,https://openlibrary.org/works/OL1955906W
+The enemy,Lee Child,N/A,2004,https://openlibrary.org/works/OL52942W
+Del amor y otros demonios,Gabriel García Márquez,N/A,1994,https://openlibrary.org/works/OL468850W
+Pyramids,Terry Pratchett,N/A,1989,https://openlibrary.org/works/OL453661W
+Odes,Horace,N/A,1635,https://openlibrary.org/works/OL88216W
+The Mark of Athena,Rick Riordan,N/A,2011,https://openlibrary.org/works/OL16664287W
+Farmer Boy,Laura Ingalls Wilder,N/A,1933,https://openlibrary.org/works/OL1719806W
+The Tin Woodman of Oz,L. Frank Baum,N/A,1918,https://openlibrary.org/works/OL262381W
+Alberto Giacometti,"Alberto Giacometti, Agnes De La Beaumell",N/A,1955,https://openlibrary.org/works/OL2206872W
+Diary of a Wimpy Kid,Jeff Kinney,N/A,2009,https://openlibrary.org/works/OL20890488W
+Maniac Magee,Jerry Spinelli,N/A,1990,https://openlibrary.org/works/OL77104W
+Beezus and Ramona,Beverly Cleary,N/A,1955,https://openlibrary.org/works/OL151996W
+The Stepford Wives,"Ira Levin, Ira Levin",N/A,1972,https://openlibrary.org/works/OL28319W
+The Forsyte Saga (various novels),John Galsworthy,N/A,1898,https://openlibrary.org/works/OL879088W
+Wide Sargasso Sea,Jean Rhys,N/A,1966,https://openlibrary.org/works/OL1858668W
+Antigone,Sophocles,N/A,1581,https://openlibrary.org/works/OL43860W
+"Sarah, plain and tall","Patricia MacLachlan, Patricia MacLachlan",N/A,1985,https://openlibrary.org/works/OL2949977W
+"A child called ""it""",David J. Pelzer,N/A,1987,https://openlibrary.org/works/OL66946W
+11/22/63,Stephen King,N/A,1925,https://openlibrary.org/works/OL16002468W
+The House with a Clock in Its Walls,John Bellairs,N/A,1973,https://openlibrary.org/works/OL3338193W
+I am Malala,"Malala Yousafzai, Christina Lamb, Malala Yousafzai, Malala Yousafazi, MALALA YOUSAFZAI ",N/A,2012,https://openlibrary.org/works/OL19669045W
+Surprised by Joy,C.S. Lewis,N/A,1955,https://openlibrary.org/works/OL71159W
+Grace abounding to the chief of sinners,John Bunyan,N/A,1666,https://openlibrary.org/works/OL107194W
+Presumed Innocent,Scott Turow,N/A,1987,https://openlibrary.org/works/OL26909W
+World Without End,Ken Follett,N/A,1961,https://openlibrary.org/works/OL1914079W
+Markens grøde,"Knut Hamsun, William John Alexander Worster",N/A,1917,https://openlibrary.org/works/OL573191W
+The dark tower,Stephen King,N/A,1990,https://openlibrary.org/works/OL81600W
+Alanna,Tamora Pierce,N/A,1954,https://openlibrary.org/works/OL29286W
+Speeches,Cicero,N/A,1499,https://openlibrary.org/works/OL15733518W
+The Red Thumb Mark,R. Austin Freeman,N/A,1907,https://openlibrary.org/works/OL4112855W
+Erewhon,Samuel Butler,N/A,1700,https://openlibrary.org/works/OL22364W
+The world of psychology,"Samuel E. Wood, Ellen Green Wood, Denise Boyd, Wood, Ellen R. Green Wood, WOOD WOOD, Ellen Wood",N/A,1992,https://openlibrary.org/works/OL103858W
+The selfish gene,"Richard Dawkins, Lalla Ward Richard Dawkins",N/A,1976,https://openlibrary.org/works/OL1966488W
+The Halloween Tree,Ray Bradbury,N/A,1972,https://openlibrary.org/works/OL103190W
+A Spy in the House of Love,"Anaïs Nin, Anita Jarczok",N/A,1954,https://openlibrary.org/works/OL278320W
+Mistress of Mellyn,Victoria Holt,N/A,1960,https://openlibrary.org/works/OL3931421W
+Black like me,John Howard Griffin,N/A,1960,https://openlibrary.org/works/OL2810429W
+Fast Food Nation,Eric Schlosser,N/A,2001,https://openlibrary.org/works/OL5801795W
+Farmer Giles of Ham,J.R.R. Tolkien,N/A,1949,https://openlibrary.org/works/OL27517W
+The White Company,Arthur Conan Doyle,N/A,1890,https://openlibrary.org/works/OL262553W
+The Secret Seven,Enid Blyton,N/A,1949,https://openlibrary.org/works/OL1948425W
+When the wind blows,James Patterson,N/A,1847,https://openlibrary.org/works/OL167187W
+The Running Man,Stephen King,N/A,1982,https://openlibrary.org/works/OL149188W
+Bacchae,Euripides,N/A,1821,https://openlibrary.org/works/OL10306674W
+Master and Commander,Patrick O'Brian,N/A,1969,https://openlibrary.org/works/OL8702048W
+The American,"Henry James, Peter Collister",N/A,1877,https://openlibrary.org/works/OL276314W
+Sophocles,Sophocles,N/A,1832,https://openlibrary.org/works/OL10327036W
+The end of the affair,Graham Greene,N/A,1951,https://openlibrary.org/works/OL106073W
+Endurance,"Alfred Lansing, Elena Grau",N/A,1959,https://openlibrary.org/works/OL874159W
+Jurgen,James Branch Cabell,N/A,1919,https://openlibrary.org/works/OL6585796W
+The Night Manager,John le Carré,N/A,1993,https://openlibrary.org/works/OL181821W
+Small Is Beautiful,E. F. Schumacher,N/A,1973,https://openlibrary.org/works/OL1622912W
+Niebla,Miguel de Unamuno,N/A,1914,https://openlibrary.org/works/OL503589W
+Murder Must Advertise,"Dorothy L. Sayers, Sai ye si, Liu zhan xun",N/A,1933,https://openlibrary.org/works/OL2235005W
+PCs for Dummies,Dan Gookin,N/A,1992,https://openlibrary.org/works/OL58572W
+Burning Daylight,Jack London,N/A,1910,https://openlibrary.org/works/OL144821W
+The Convenient Marriage,Georgette Heyer,N/A,1934,https://openlibrary.org/works/OL4092655W
+The Witch of Blackbird Pond,Elizabeth George Speare,N/A,1958,https://openlibrary.org/works/OL4783032W
+Diamonds are Forever,Ian Fleming,N/A,1956,https://openlibrary.org/works/OL85747W
+De amor y de sombra,Isabel Allende,N/A,1984,https://openlibrary.org/works/OL1905374W
+The Indian in the Cupboard,Lynne Reid Banks,N/A,1980,https://openlibrary.org/works/OL50627W
+Midwinter,John Buchan,N/A,1923,https://openlibrary.org/works/OL76588W
+The twenty-one balloons,"William Pène Du Bois, John McDonough",N/A,1947,https://openlibrary.org/works/OL5279534W
+Sophie's Choice,William Styron,N/A,1979,https://openlibrary.org/works/OL86543W
+The Circle,Dave Eggers,N/A,2013,https://openlibrary.org/works/OL16808654W
+The beach house,"James Patterson, Peter de Jonge, Peter De Jonge",N/A,2001,https://openlibrary.org/works/OL167183W
+De la division du travail social,"Émile Durkheim, Steven Lukes, George Simpson",N/A,1893,https://openlibrary.org/works/OL606930W
+Jack and Jill: a village story,"Louisa May Alcott, Amy Puetz, Harriet Roosevelt Richards, Jane Dyer",N/A,1880,https://openlibrary.org/works/OL30033W
+Pamela,Samuel Richardson,N/A,1741,https://openlibrary.org/works/OL1150772W
+Honeymoon,"James Patterson, Howard Roughan",N/A,2001,https://openlibrary.org/works/OL167160W
+The Chrysalids,John Wyndham,N/A,1955,https://openlibrary.org/works/OL1911334W
+The Spook's Apprentice,Joseph Delaney,N/A,1998,https://openlibrary.org/works/OL275974W
+The hours,Michael Cunningham,N/A,1998,https://openlibrary.org/works/OL30838W
+The Haunted Man and the Ghost's Bargain,"Charles Dickens, Sir John Tenniel, Frank Stone",N/A,1848,https://openlibrary.org/works/OL14869114W
+The illustrated naked ape,Desmond Morris,N/A,1772,https://openlibrary.org/works/OL104128W
+Captain Underpants and the Wrath of the Wicked Wedgie Woman,Dav Pilkey,N/A,2001,https://openlibrary.org/works/OL9741465W
+Journal of researches into the geology and natural history of the various countries visited by H.M.S. Beagle,Charles Darwin,N/A,1839,https://openlibrary.org/works/OL15155498W
+Interesting Times,Terry Pratchett,N/A,1994,https://openlibrary.org/works/OL453707W
+Poems,"Gilbert Keith Chesterton, Gerald Gould, Skye Banks",N/A,1891,https://openlibrary.org/works/OL76320W
+The History of England from the accession of James the Second,Thomas Babington Macaulay,N/A,1800,https://openlibrary.org/works/OL1237783W
+The Lodger,Marie Belloc Lowndes,N/A,1913,https://openlibrary.org/works/OL1172118W
+La dame aux camélias [novel],Alexandre Dumas fils,N/A,1848,https://openlibrary.org/works/OL259509W
+Fall of Giants,Ken Follett,N/A,2010,https://openlibrary.org/works/OL15382656W
+The joy of sex,"Alex Comfort, Alex Comfort",N/A,1972,https://openlibrary.org/works/OL1174239W
+The Last Unicorn,Peter S. Beagle,N/A,1968,https://openlibrary.org/works/OL26459W
+Bath Tangle,Georgette Heyer,N/A,1955,https://openlibrary.org/works/OL4092688W
+Constitution,India,N/A,1947,https://openlibrary.org/works/OL296280W
+American Psycho,"Bret Easton Ellis, Mariano Antolín Rato",N/A,1991,https://openlibrary.org/works/OL1812933W
+Memnoch the Devil,Anne Rice,N/A,1995,https://openlibrary.org/works/OL77847W
+The Corinthian,Georgette Heyer,N/A,1940,https://openlibrary.org/works/OL4092656W
+The Book of Lost Tales [1/2],J.R.R. Tolkien,N/A,1983,https://openlibrary.org/works/OL27435W
+Oblomov,Ivan Aleksandrovich Goncharov,N/A,1913,https://openlibrary.org/works/OL1139069W
+Tintin en Amérique,Hergé,N/A,1962,https://openlibrary.org/works/OL151089W
+The Children of Men,P. D. James,N/A,1992,https://openlibrary.org/works/OL510890W
+We Have Always Lived in the Castle,"Shirley Jackson, Bernadette Dunne",N/A,1962,https://openlibrary.org/works/OL3171087W
+Diary of a Wimpy Kid,Jeff Kinney,N/A,2017,https://openlibrary.org/works/OL17812914W
+The Practice of Management,Peter F. Drucker,N/A,1954,https://openlibrary.org/works/OL274337W
+Bhagavad-Gita,Vyasa,N/A,1944,https://openlibrary.org/works/OL264706W
+One for the Money,"Janet Evanovich, Janet Evanovich",N/A,1994,https://openlibrary.org/works/OL48035W
+Liebeszauber,Louise Erdrich,N/A,1984,https://openlibrary.org/works/OL479009W
+Wild Animal Coloring Book,Katty Green,N/A,2020,https://openlibrary.org/works/OL30585610W
+Aus meinem Leben,Johann Wolfgang von Goethe,N/A,1800,https://openlibrary.org/works/OL52470W
+Peter's Chair,Ezra Jack Keats,N/A,1967,https://openlibrary.org/works/OL831062W
+Men at Arms,Terry Pratchett,N/A,1993,https://openlibrary.org/works/OL453739W
+Kniha smíchu a zapomnění,Milan Kundera,N/A,1979,https://openlibrary.org/works/OL10402330W
+Stoner,John Williams,N/A,1965,https://openlibrary.org/works/OL3511459W
+Phantoms,Dean Koontz,N/A,1983,https://openlibrary.org/works/OL263259W
+Blubber,Judy Blume,N/A,1972,https://openlibrary.org/works/OL1838312W
+A Bear Called Paddington,Michael Bond,N/A,1960,https://openlibrary.org/works/OL10490647W
+The Mediterranean Caper,Clive Cussler,N/A,1973,https://openlibrary.org/works/OL84877W
+Greenmantle,John Buchan,N/A,1915,https://openlibrary.org/works/OL76501W
+The Underground Railroad,Colson Whitehead,N/A,2000,https://openlibrary.org/works/OL17619932W
+Light on Yoga,B. K. S. Iyengar,N/A,1965,https://openlibrary.org/works/OL262821W
+The Mixed-Up Chameleon,Eric Carle,N/A,1975,https://openlibrary.org/works/OL52978W
+Skellig,David Almond,N/A,1998,https://openlibrary.org/works/OL469108W
+The Coral Island,"Robert Michael Ballantyne, Ralph Crane, Pradip Das, George Dalziel, Edward Dalziel",N/A,1858,https://openlibrary.org/works/OL2319934W
+Implementation of the Helsinki accords,United States. Congress. Commission on Security and Cooperation in Europe,N/A,1982,https://openlibrary.org/works/OL133442W
+The City of Ember (The First Book of Ember),Jeanne DuPrau,N/A,1998,https://openlibrary.org/works/OL4132752W
+All the Pretty Horses,Cormac McCarthy,N/A,1992,https://openlibrary.org/works/OL40882W
+The Outline of History,H. G. Wells,N/A,1919,https://openlibrary.org/works/OL52264W
+The Tale of the Body Thief,Anne Rice,N/A,1992,https://openlibrary.org/works/OL77842W
+The Wishing Spell,Chris Colfer,N/A,1990,https://openlibrary.org/works/OL16585191W
+The wood beyond the world,"William Morris, William Norris, William, Morris, William Morris, William William Morris, WILLIAM MORRIS, Random House",N/A,1894,https://openlibrary.org/works/OL47752W
+Vers une architecture,"Le Corbusier, Hans Hildebrandt",N/A,1923,https://openlibrary.org/works/OL15164456W
+A history of New York,Washington Irving,N/A,1800,https://openlibrary.org/works/OL63871W
+The Last Juror,John Grisham,N/A,2003,https://openlibrary.org/works/OL77013W
+Hospital Sketches,Louisa May Alcott,N/A,1863,https://openlibrary.org/works/OL30060W
+Study Guide,SuperSummary,N/A,2018,https://openlibrary.org/works/OL28775081W
+Rising Tides,Nora Roberts,N/A,1998,https://openlibrary.org/works/OL111439W
+Speaker for the Dead,Orson Scott Card,N/A,1986,https://openlibrary.org/works/OL49580W
+Where the Crawdads Sing,Delia Owens,N/A,2018,https://openlibrary.org/works/OL18766691W
+The Enchanted Wood,Enid Blyton,N/A,1939,https://openlibrary.org/works/OL1948444W
+Hidden Figures,"Margot Lee Shetterly, Winifred Conkling, Laura Freeman, Hayley Cresswell, Carlos Ramos Malave",N/A,2016,https://openlibrary.org/works/OL17598637W
+The postman always rings twice,James M. Cain,N/A,1934,https://openlibrary.org/works/OL3480719W
+Feel the fear and do it anyway,Susan J. Jeffers,N/A,1987,https://openlibrary.org/works/OL1884125W
+The Seven Storey Mountain,Thomas Merton,N/A,1948,https://openlibrary.org/works/OL461723W
+Devil's Cub (Alastair-Audley #2),Georgette Heyer,N/A,1932,https://openlibrary.org/works/OL4092689W
+"Treaties, etc",Rand McNally,N/A,1714,https://openlibrary.org/works/OL14903377W
+The Austere Academy,"Lemony Snicket, Brett Helquist, Michael Kupperman",N/A,2000,https://openlibrary.org/works/OL15104126W
+The Word for World is Forest,Ursula K. Le Guin,N/A,1972,https://openlibrary.org/works/OL59797W
+Night of the Living Dummy,Robert Lawrence Stine,N/A,1993,https://openlibrary.org/works/OL72425W
+Poems,William Cowper,N/A,1782,https://openlibrary.org/works/OL1114694W
+Ariel,"Sylvia Plath, Sara Fernández Morante, Jordi Doce Chambrelán",N/A,1965,https://openlibrary.org/works/OL1865549W
+The Good Soldier,Ford Madox Ford,N/A,1915,https://openlibrary.org/works/OL509889W
+"Then Again, Maybe I Won't",Judy Blume,N/A,1971,https://openlibrary.org/works/OL1838412W
+Melmoth the Wanderer,Charles Robert Maturin,N/A,1820,https://openlibrary.org/works/OL2458892W
+Fundamentals of physics,"David Halliday, Robert Resnick, Jearl  Walker",N/A,1970,https://openlibrary.org/works/OL2538490W
+Treasure,"Clive Cussler, Justin Scott",N/A,1988,https://openlibrary.org/works/OL84919W
+Big Nate,Lincoln Peirce,N/A,2010,https://openlibrary.org/works/OL34357614W
+The ABC of atoms,Bertrand Russell,N/A,1923,https://openlibrary.org/works/OL1088556W
+Lysistrata,Aristophanes,N/A,1872,https://openlibrary.org/works/OL20248W
+The Crystal Cave,"Mary Stewart, Mary Stwart",N/A,1970,https://openlibrary.org/works/OL213256W
+The White Mountains (The Tripods #1),Sam Youd,N/A,1967,https://openlibrary.org/works/OL3972834W
+Kiss the Girls,James Patterson,N/A,1995,https://openlibrary.org/works/OL167171W
+The Feminine Mystique,Betty Friedan,N/A,1963,https://openlibrary.org/works/OL2643698W
+Haroun and the Sea of Stories,Salman Rushdie,N/A,1990,https://openlibrary.org/works/OL457172W
+Dragonfly in Amber,Diana Gabaldon,N/A,1992,https://openlibrary.org/works/OL3261153W
+Mystic river,Dennis Lehane,N/A,2001,https://openlibrary.org/works/OL17211W
+The spy who loved me,Ian Fleming,N/A,1960,https://openlibrary.org/works/OL85742W
+Gaudy night,Dorothy L. Sayers,N/A,1935,https://openlibrary.org/works/OL2234851W
+High Fidelity,Nick Hornby,N/A,1995,https://openlibrary.org/works/OL1916907W
+三体,"刘慈欣, Vincent Schmitt, Gwennaël Gaffric, Marc Simonetti",N/A,2008,https://openlibrary.org/works/OL17267881W
+Stay Out of the Basement,Robert Lawrence Stine,N/A,1992,https://openlibrary.org/works/OL72428W
+Swimmy,"Leo Lionni, Xosé Manuel González, Ignasi Centelles",N/A,1963,https://openlibrary.org/works/OL2162545W
+Loving,Danielle Steel,N/A,1980,https://openlibrary.org/works/OL19560W
+Déjà Dead,Kathy Reichs,N/A,1997,https://openlibrary.org/works/OL8075674W
+The Daybreakers,Louis L'Amour,N/A,1960,https://openlibrary.org/works/OL50898W
+Bushidō,"Inazo Nitobe, Stefano Daniel, Alberto Ragagnin, Gonzalo JIMENEZ DE LA ESPADA, Peter R. Prifti, Daniel Herwitz, José Javier Fuente del Pilar, Ricard Vela Pàmies, Z. Ferri",N/A,1899,https://openlibrary.org/works/OL1154715W
+Dialogues Concerning Natural Religion,David Hume,N/A,1779,https://openlibrary.org/works/OL93568W
+Two Gentlemen of Verona,William Shakespeare,N/A,1632,https://openlibrary.org/works/OL362671W
+Biology,Sylvia S. Mader,N/A,1985,https://openlibrary.org/works/OL2657847W
+The light princess,George MacDonald,N/A,1926,https://openlibrary.org/works/OL15428W
+Taltos,Anne Rice,N/A,1994,https://openlibrary.org/works/OL77856W
+Molecular Biology of the Cell,"Bruce Alberts, Alexander Johnson, Julian Lewis, David O Morgan, Martin Raff, Julian Lewis, Keith Roberts, Peter Walter, Alexander D. Johnson",N/A,1983,https://openlibrary.org/works/OL7938488W
+Rewards and fairies,Rudyard Kipling,N/A,1910,https://openlibrary.org/works/OL20161W
+The Hidden Oracle,Rick Riordan,N/A,2016,https://openlibrary.org/works/OL17364743W
+Dawn,V. C. Andrews,N/A,1990,https://openlibrary.org/works/OL134880W
+The idea of a university,John Henry Newman,N/A,1873,https://openlibrary.org/works/OL1144814W
+The Ersatz Elevator,"Lemony Snicket, Brett Helquist, Michael Kupperman, Veronica Canales",N/A,2001,https://openlibrary.org/works/OL15104128W
+Secrets of the Morning,V. C. Andrews,N/A,1991,https://openlibrary.org/works/OL134885W
+Arrowsmith,"Sinclair Lewis, José Manuel Álvarez Flórez, Barbara Grace Spayd",N/A,1925,https://openlibrary.org/works/OL51147W
+Journal,Henry David Thoreau,N/A,1906,https://openlibrary.org/works/OL55611W
+The Time Traders,Andre Norton,N/A,1958,https://openlibrary.org/works/OL473477W
+The Talisman Ring,Georgette Heyer,N/A,1936,https://openlibrary.org/works/OL4092602W
+The Sword of Summer,Rick Riordan,N/A,2015,https://openlibrary.org/works/OL17181541W
+Ramona the Brave,Beverly Cleary,N/A,1975,https://openlibrary.org/works/OL151951W
+Τίμαιος,Πλάτων,N/A,1520,https://openlibrary.org/works/OL51823W
+Собачье сердце,Михаил Афанасьевич Булгаков,N/A,1968,https://openlibrary.org/works/OL260422W
+Rotkäppchen,"Charles Perrault, Gebrüder Grimm [Brothers Grimm]",N/A,1945,https://openlibrary.org/works/OL45429W
+"Diana, Her True Story",Andrew Morton,N/A,1992,https://openlibrary.org/works/OL461064W
+Atomic Habits,James Clear,N/A,2016,https://openlibrary.org/works/OL17930368W
+Psychic self-defence,Violet M. Firth (Dion Fortune),N/A,1930,https://openlibrary.org/works/OL114618W
+A Walk in the Woods,Bill Bryson,N/A,1997,https://openlibrary.org/works/OL74123W
+The Things They Carried,Tim O'Brien,N/A,1990,https://openlibrary.org/works/OL2919959W
+Diarios de Motocicleta,"Che Guevara, Ann Wright, Ernesto; Wright, Ann (translator) Guevara, Aleida Guevara, Walter Salles, Cintio Vitier",N/A,1993,https://openlibrary.org/works/OL63457W
+The Fires of Heaven,Robert Jordan,N/A,1993,https://openlibrary.org/works/OL7924172W
+Sesame and lilies,John Ruskin,N/A,1800,https://openlibrary.org/works/OL88641W
+Nova Atlantis,Francis Bacon,N/A,1627,https://openlibrary.org/works/OL69453W
+The Paper Bag Princess (Classic Munsch),Robert N Munsch,N/A,1980,https://openlibrary.org/works/OL88684W
+The Old Man in the Corner,"Emmuska Orczy, Baroness Orczy",N/A,1908,https://openlibrary.org/works/OL1253282W
+"Works [37 plays, 5 poems, sonnets]",William Shakespeare,N/A,1794,https://openlibrary.org/works/OL361393W
+Rooster who set out to see the world,Eric Carle,N/A,1971,https://openlibrary.org/works/OL53026W
+The old wives' tale,"Arnold Bennett, Intro. & Notes John Wain Arnold Bennett",N/A,1900,https://openlibrary.org/works/OL109236W
+The Song of Achilles,"Madeline Miller, José Miguel Pallarés Sanmiguel",N/A,2011,https://openlibrary.org/works/OL16509148W
+What If?,Randall Munroe,N/A,1980,https://openlibrary.org/works/OL17095301W
+Chilton's repair and tune-up guide,The Nichols/Chilton Editors,N/A,1970,https://openlibrary.org/works/OL5608969W
+The Yellow Wallpaper,Charlotte Perkins Gilman,N/A,1899,https://openlibrary.org/works/OL2772007W
+Seeds of Yesterday,V. C. Andrews,N/A,1984,https://openlibrary.org/works/OL134853W
+Feet of Clay,Terry Pratchett,N/A,1996,https://openlibrary.org/works/OL453743W
+Absolute Power,David Baldacci,N/A,1995,https://openlibrary.org/works/OL41258W
+"Ancient law, its connection with the early history of society and its relaton to modern ideas","Henry James Sumner Maine, Dante J. Scala",N/A,1861,https://openlibrary.org/works/OL2026854W
+Player Piano,Kurt Vonnegut,N/A,1952,https://openlibrary.org/works/OL98484W
+The Song of Hiawatha and Other Poems,Henry Wadsworth Longfellow,N/A,1800,https://openlibrary.org/works/OL495934W
+The Tao of Physics,Fritjof Capra,N/A,1975,https://openlibrary.org/works/OL3258255W
+Pan,"Knut Hamsun, Tore Rem, Terence Cave",N/A,1900,https://openlibrary.org/works/OL573192W
+Emily climbs,"Lucy Maud Montgomery, Pixabay, Paula Benitez (editor)",N/A,1920,https://openlibrary.org/works/OL77777W
+The fountains of paradise,Arthur C. Clarke,N/A,1978,https://openlibrary.org/works/OL17403W
+House of Hades,Rick Riordan,N/A,2013,https://openlibrary.org/works/OL16807730W
+Captain Underpants and the Perilous Plot of Professor Poopypants,Dav Pilkey,N/A,2000,https://openlibrary.org/works/OL14871282W
+Chemistry,James E. Brady,N/A,1981,https://openlibrary.org/works/OL477707W
+The Husband,Dean Koontz,N/A,2006,https://openlibrary.org/works/OL263251W
+Captain Underpants and the Preposterous Plight of the Purple Potty People,Dav Pilkey,N/A,2006,https://openlibrary.org/works/OL14871259W
+Troilus and Cressida,William Shakespeare,N/A,1609,https://openlibrary.org/works/OL362685W
+The Son of Neptune,Rick Riordan,N/A,2011,https://openlibrary.org/works/OL15980243W
+The great conversation,Norman Melchert,N/A,1991,https://openlibrary.org/works/OL1810842W
+The Great Divorce,C.S. Lewis,N/A,1945,https://openlibrary.org/works/OL71014W
+Don't Let the Pigeon Drive the Bus!,Mo Willems,N/A,2003,https://openlibrary.org/works/OL5760013W
+The Master Key,L. Frank Baum,N/A,1901,https://openlibrary.org/works/OL262383W
+Last Exit to Brooklyn,"Hubert Selby, Jr., Selby, Hubert, Jr., Hubert Selby Jr., Hubert Jr Selby, Selby",N/A,1964,https://openlibrary.org/works/OL2737302W
+Black Beauty,Anna Sewell,N/A,1945,https://openlibrary.org/works/OL28841657W
+The tower treasure,Franklin W. Dixon,N/A,1927,https://openlibrary.org/works/OL47915W
+Reaper Man,Terry Pratchett,N/A,1991,https://openlibrary.org/works/OL453654W
+The Door in the Wall,"Marguerite de Angeli, Paul Champanier, Linda Stewart, José Luis Haering",N/A,1949,https://openlibrary.org/works/OL112822W
+The Gilded Age,"Mark Twain, Charles Dudley Warner",N/A,1873,https://openlibrary.org/works/OL15290078W
+What is life? The physical aspect of the living cell,"Erwin Schrödinger, Roger Penrose",N/A,1944,https://openlibrary.org/works/OL1210514W
+人間失格,太宰 治,N/A,1948,https://openlibrary.org/works/OL3923952W
+The Serpent's Shadow,Rick Riordan,N/A,2012,https://openlibrary.org/works/OL16571997W
+Menschenkenntnis,"Alfred Adler, Colin Brett",N/A,1927,https://openlibrary.org/works/OL1127269W
+Lasher,Anne Rice,N/A,1993,https://openlibrary.org/works/OL77829W
+Rip Van Winkle,Washington Irving,N/A,1850,https://openlibrary.org/works/OL63995W
+The Patchwork Girl of Oz,L. Frank Baum,N/A,1913,https://openlibrary.org/works/OL18405W
+Kodeks pracy,Poland.,N/A,1693,https://openlibrary.org/works/OL89171W
+The mysterious Mr Quin,Agatha Christie,N/A,1930,https://openlibrary.org/works/OL472043W
+The Defendant,Gilbert Keith Chesterton,N/A,1901,https://openlibrary.org/works/OL76348W
+Pale fire,"Vladimir Nabokov, Uwe friesel (Nachwort), Uwe Friesel, Robert Blumenfeld Marc Vietor",N/A,1962,https://openlibrary.org/works/OL627081W
+'Twas the Night before Christmas,"Clement Clarke Moore, Anonymous, Jon Goodell, Jessie Wilcox Smith, Mark Marshall, Raquel Martin Peinado, Jessie Smith, Applewood Applewood Books, Erwin Hess, Birchall Publishing",N/A,1912,https://openlibrary.org/works/OL20262024W
+Perelandra,C.S. Lewis,N/A,1943,https://openlibrary.org/works/OL71163W
+And the Mountains Echoed,Khaled Hosseini,N/A,2013,https://openlibrary.org/works/OL16804912W
+Xenocide,Orson Scott Card,N/A,1991,https://openlibrary.org/works/OL49604W
+The Woods,Harlan Coben,N/A,2007,https://openlibrary.org/works/OL79339W
+Дядя Ваня,Антон Павлович Чехов,N/A,1897,https://openlibrary.org/works/OL55527W
+The True Confessions of Charlotte Doyle,Avi,N/A,1990,https://openlibrary.org/works/OL265958W
+The Well of Ascension,Brandon Sanderson,N/A,2007,https://openlibrary.org/works/OL5738150W
+The Hard Way,Lee Child,N/A,2006,https://openlibrary.org/works/OL52940W
+Troilus and Criseyde,Geoffrey Chaucer,N/A,1483,https://openlibrary.org/works/OL531509W
+The song of Hiawatha,"Henry Wadsworth Longfellow, Jeff Ulmer, Alex A. Blum",N/A,1855,https://openlibrary.org/works/OL495872W
+Benim Adım Kırmızı,Orhan Pamuk,N/A,1998,https://openlibrary.org/works/OL1019598W
+The Red Badge of Courage,Stephen Crane,N/A,1871,https://openlibrary.org/works/OL25649539W
+Lettres philosophiques,Voltaire,N/A,1733,https://openlibrary.org/works/OL15228532W
+Caesar and Cleopatra,George Bernard Shaw,N/A,1900,https://openlibrary.org/works/OL1066521W
+The Girl on the Train,Paula Hawkins,N/A,2014,https://openlibrary.org/works/OL17112428W
+Oranges Are Not the Only Fruit,Jeanette Winterson,N/A,1985,https://openlibrary.org/works/OL1918804W
+1Q84,村上春樹,N/A,2009,https://openlibrary.org/works/OL15029001W
+Parker Pyne Investigates,Agatha Christie,N/A,1933,https://openlibrary.org/works/OL472884W
+The story of the other wise man,"Henry van Dyke, Ruth Sergel, Pamela Kennedy, Gabriel Bradford Millar, Ruth Fuller Sergel, Michael Lynberg, J. R. Flanagan, H. van Dyke, Bryan Hunt, A. J. Alexander",N/A,1895,https://openlibrary.org/works/OL2254120W
+An Arabian tale,"William Beckford, Samuel Henley, Richard Garnett , Samuel Henley, Franz Blei, John Beckford, Giaime Giaime Pintor",N/A,1786,https://openlibrary.org/works/OL777826W
+Prelude to Foundation,Isaac Asimov,N/A,1988,https://openlibrary.org/works/OL46172W
+Tai-Pan (Asian Saga,James Clavell,N/A,1966,https://openlibrary.org/works/OL2918760W
+Snow Falling on Cedars,David Guterson,N/A,1994,https://openlibrary.org/works/OL8036957W
+Surprise Island,Gertrude Chandler Warner,N/A,1949,https://openlibrary.org/works/OL15142W
+Busman's honeymoon,Dorothy L. Sayers,N/A,1937,https://openlibrary.org/works/OL2234807W
+Mutter Courage und ihre Kinder,Bertolt Brecht,N/A,1949,https://openlibrary.org/works/OL3802689W
+Kommandant in Auschwitz,Rudolf Höss,N/A,1956,https://openlibrary.org/works/OL2969387W
+The Road to Serfdom,Friedrich A. von Hayek,N/A,1944,https://openlibrary.org/works/OL1165001W
+The Blood of Olympus,Rick Riordan,N/A,2014,https://openlibrary.org/works/OL17059943W
+Beyond Good and Evil,"Friedrich Nietzsche, Helen Zimmern",N/A,2009,https://openlibrary.org/works/OL24784277W
+The Long Walk,Stephen King,N/A,1979,https://openlibrary.org/works/OL9973101W
+The Alibi,Sandra Brown,N/A,1999,https://openlibrary.org/works/OL167331W
+Citizen of the Galaxy,Robert A. Heinlein,N/A,1957,https://openlibrary.org/works/OL59679W
+Venetia,Georgette Heyer,N/A,1958,https://openlibrary.org/works/OL4092681W
+It Ends With Us,Colleen Hoover,N/A,2012,https://openlibrary.org/works/OL18020194W
+The master of Ballantrae,Robert Louis Stevenson,N/A,1888,https://openlibrary.org/works/OL24164W
+The Birds of America,John James Audubon,N/A,1827,https://openlibrary.org/works/OL74757W
+The Selection (The Selection #1),Kiera Cass,N/A,2012,https://openlibrary.org/works/OL16361029W
+Naruto 5,"Masashi Kishimoto, Frances Wall",N/A,2003,https://openlibrary.org/works/OL8756057W
+Illusions,Richard Bach,N/A,1977,https://openlibrary.org/works/OL62095W
+Vogue Knitting on the Go,Trisha Malcolm,N/A,1999,https://openlibrary.org/works/OL8922433W
+Mas̲navī,"Rumi (Jalāl ad-Dīn Muḥammad Balkhī), Camille Adams Helminski, Kabir Helminski",N/A,1851,https://openlibrary.org/works/OL18993W
+The Robber Bride,Margaret Atwood,N/A,1993,https://openlibrary.org/works/OL675751W
+Sky Island,L. Frank Baum,N/A,1912,https://openlibrary.org/works/OL262385W
+Time Traveler's Wife,"Audrey Niffenegger, William Hope, Laurel Lefkow",N/A,2003,https://openlibrary.org/works/OL4720160W
+The switch,Sandra Brown,N/A,2000,https://openlibrary.org/works/OL167314W
+Farewell to Manzanar,"Jeanne Wakatsuki Houston, James D. Houston",N/A,1758,https://openlibrary.org/works/OL6026098W
+White oleander,"Fitch, Janet",N/A,1989,https://openlibrary.org/works/OL48010W
+The Moon-Spinners,Mary Stewart,N/A,1962,https://openlibrary.org/works/OL213273W
+World War Z,Max Brooks,N/A,2006,https://openlibrary.org/works/OL5969057W
+Purple Hibiscus,Chimamanda Ngozi Adichie,N/A,2003,https://openlibrary.org/works/OL5731538W
+Our American hero,J. K. Ronayne,N/A,2007,https://openlibrary.org/works/OL11878649W
+"Clarissa; or, The history of a young lady: comprehending the most important concerns of private life; and particularly shewing the distresses that may attend the misconduct both of parents and children, in relation to marriage ..",Samuel Richardson,N/A,1748,https://openlibrary.org/works/OL1150725W
+The Casual Vacancy,"J. K. Rowling, Tom Hollander",N/A,2012,https://openlibrary.org/works/OL16796166W
+Frogs,Aristophanes,N/A,1785,https://openlibrary.org/works/OL20246W
+The secret doctrine,Елена Петровна Блаватская,N/A,1888,https://openlibrary.org/works/OL2604017W
+The Long Dark Tea-Time of the Soul,Douglas Adams,N/A,1988,https://openlibrary.org/works/OL2163629W
+Ready Player One,"Ernest Cline, Arnaud Regnauld, Ernest Cline",N/A,2008,https://openlibrary.org/works/OL15936512W
+All the President's Men,"Carl Bernstein, Bob Woodward",N/A,1974,https://openlibrary.org/works/OL46932W
+La reine Margot,Alexandre Dumas,N/A,1844,https://openlibrary.org/works/OL36827W
+Cat & Mouse,James Patterson,N/A,1997,https://openlibrary.org/works/OL167169W
+Mördare utan ansikte,Henning Mankell,N/A,1993,https://openlibrary.org/works/OL158674W
+The Virgin Suicides (Bloomsbury Classic),"Jeffrey Eugenides, Nick Landrum",N/A,1993,https://openlibrary.org/works/OL3951517W
+Cloud Atlas,David Mitchell,N/A,2004,https://openlibrary.org/works/OL482454W
+Pop goes the weasel,James Patterson,N/A,1999,https://openlibrary.org/works/OL167182W
+Ten days in a mad-house,"Nellie Bly, Nellie Bly, BookCaps",N/A,1905,https://openlibrary.org/works/OL16915826W
+The Innocent Man,John Grisham,N/A,2006,https://openlibrary.org/works/OL77015W
+Barchester Towers,Anthony Trollope,N/A,1857,https://openlibrary.org/works/OL109724W
+"The Surgeon (Jane Rizzoli, Book 1)","Tess Gerritsen, Tess Gerritsen",N/A,2001,https://openlibrary.org/works/OL14871640W
+Guide to Exploration,"Mojang, The Official Minecraft Team",N/A,2017,https://openlibrary.org/works/OL21351323W
+The art of happiness,"His Holiness Tenzin Gyatso the XIV Dalai Lama, Howard C. Cutler",N/A,1998,https://openlibrary.org/works/OL318761W
+The Shadow Rising,Robert Jordan,N/A,1992,https://openlibrary.org/works/OL7924199W
+Saving the World and Other Extreme Sports,"James Patterson, Valentina de Angelis",N/A,1998,https://openlibrary.org/works/OL5337360W
+Gravity's Rainbow,Thomas Pynchon,N/A,1973,https://openlibrary.org/works/OL2636675W
+Say Cheese and Die!,Robert Lawrence Stine,N/A,1992,https://openlibrary.org/works/OL72434W
+Madame Curie,"Curie, Eve",N/A,1937,https://openlibrary.org/works/OL1439437W
+Hogfather,Terry Pratchett,N/A,1996,https://openlibrary.org/works/OL453662W
+Peter Pan in Kensington Gardens,J. M. Barrie,N/A,1906,https://openlibrary.org/works/OL462123W
+Reach for the Sky,Paul Brickhill,N/A,1954,https://openlibrary.org/works/OL3241394W
+"The principall navigations, voiages, and discoveries of the English nations","Richard Hakluyt, Jack Beeching, Richard David, Edmund Goldsmid",N/A,1589,https://openlibrary.org/works/OL3639910W
+Válka s mloky,Karel Čapek,N/A,1936,https://openlibrary.org/works/OL575639W
+The Wild Knight and Other Poems,Gilbert Keith Chesterton,N/A,1900,https://openlibrary.org/works/OL76404W
+The Amazing Adventures of Kavalier & Clay,Michael Chabon,N/A,1957,https://openlibrary.org/works/OL119436W
+The snowman,Raymond Briggs,N/A,1978,https://openlibrary.org/works/OL15845200W
+The Hundred Dresses,"Eleanor Estes, Louis Slobodkin, Jim Stelljes, Louis Slobodkin, Estes",N/A,1944,https://openlibrary.org/works/OL78547W
+The Sheltering Sky,Paul Bowles,N/A,1948,https://openlibrary.org/works/OL2066162W
+Clifford the Big Red Dog,Norman Bridwell,N/A,1963,https://openlibrary.org/works/OL73128W
+The Rosie Project,Graeme Simsion,N/A,2013,https://openlibrary.org/works/OL16813583W
+De profundis,Oscar Wilde,N/A,1905,https://openlibrary.org/works/OL14877880W
+Star Wars - Thrawn Trilogy - Heir to the Empire,Timothy Zahn,N/A,1991,https://openlibrary.org/works/OL83589W
+Sanctuary,William Faulkner,N/A,1931,https://openlibrary.org/works/OL82925W
+King Henry VIII,William Shakespeare,N/A,1670,https://openlibrary.org/works/OL361246W
+Transactions on Engineering Technologies,"Sio-Iong Ao, Haeng Kon Kim, Oscar Castillo, Alan Hoi-shou Chan, Hideki Katagiri",N/A,2013,https://openlibrary.org/works/OL20667190W
+Harry Potter and the Cursed Child,"Jack Thorne, John Tiffany, J. K. Rowling",N/A,2001,https://openlibrary.org/works/OL17360811W
+Vita nuova,"Dante Alighieri, Dante Gabriel Rossetti, Michael Palmer, Dante Rossetti, Roger Grass",N/A,1829,https://openlibrary.org/works/OL93228W
+The Amulet of Samarkand,Jonathan Stroud,N/A,2003,https://openlibrary.org/works/OL85675W
+The Dance of Anger,Harriet Goldhor Lerner,N/A,1985,https://openlibrary.org/works/OL271818W
+"The Little Mouse, the Ripe Red Strawberry, and the Big Hungry Bear","Audrey Wood, Don Wood",N/A,1945,https://openlibrary.org/works/OL547420W
+The Angel Experiment,"James Patterson, Copyright Paperback Collection (Library of Congress) Staff",N/A,2001,https://openlibrary.org/works/OL167174W
+"Full Dark, No Stars",Stephen King,N/A,2010,https://openlibrary.org/works/OL15374110W
+Welcome to Dead House,Robert Lawrence Stine,N/A,1992,https://openlibrary.org/works/OL72352W
+Culture and anarchy; an essay in political and social criticism,"Matthew Arnold, Matthew Arnold, M Arnold, Matthew (Edited with an Introduction By J. Dover Wilson) Arnold, George Saintsbury, George William Erskine Russell, Marciano Guerrero",N/A,1869,https://openlibrary.org/works/OL1336695W
+Houghton Mifflin Vocabulary Readers,Houghton Mifflin Company Staff,N/A,2005,https://openlibrary.org/works/OL27468184W
+The Lost Continent,Bill Bryson,N/A,1989,https://openlibrary.org/works/OL74124W
+Le chat botté,Charles Perrault,N/A,1865,https://openlibrary.org/works/OL23867W
+Never Cry Wolf,Farley Mowat,N/A,1963,https://openlibrary.org/works/OL479072W
+The Awakening,Lisa Jane Smith,N/A,1991,https://openlibrary.org/works/OL277730W
+Between the Acts,"Virginia Woolf, Stella McNichol, Gillian Beer, Mark Hussey",N/A,1941,https://openlibrary.org/works/OL39567W
+Areopagitica,"John Milton, John Milton",N/A,1644,https://openlibrary.org/works/OL810614W
+The Yiddish Policemen's Union,Michael Chabon,N/A,2006,https://openlibrary.org/works/OL119430W
+"2010, odyssey two",Arthur C. Clarke,N/A,1982,https://openlibrary.org/works/OL17391W
+Narziss und Goldmund,Hermann Hesse,N/A,1930,https://openlibrary.org/works/OL873100W
+Human Anatomy & Physiology,Elaine Nicpon Marieb,N/A,1981,https://openlibrary.org/works/OL15161165W
+By The Great Horn Spoon,Sid Fleischman,N/A,1963,https://openlibrary.org/works/OL114723W
+Eichmann in Jerusalem,Hannah Arendt,N/A,1963,https://openlibrary.org/works/OL1386647W
+Joan Miró,"Joan Miró, Stephan Von Wiese, Sylvia Martin, Victoria Combalia Dexeus, Joaquim Gomis",N/A,1937,https://openlibrary.org/works/OL578528W
+Possession,A. S. Byatt,N/A,1890,https://openlibrary.org/works/OL115647W
+Go Ask Alice,Beatrice Sparks,N/A,1971,https://openlibrary.org/works/OL264729W
+The One and Only Ivan,Katherine Applegate,N/A,2011,https://openlibrary.org/works/OL16465449W
+The three stigmata of Palmer Eldritch,"Philip K. Dick, Luke Daniels",N/A,1965,https://openlibrary.org/works/OL2172402W
+Wet Magic,Edith Nesbit,N/A,1937,https://openlibrary.org/works/OL99513W
+Le Balcon,Jean Genet,N/A,1956,https://openlibrary.org/works/OL7435395W
+Kensuke's kingdom,Michael Morpurgo,N/A,1999,https://openlibrary.org/works/OL42746W
+Jingo,Terry Pratchett,N/A,1996,https://openlibrary.org/works/OL453727W
+Dragonsong,Anne McCaffrey,N/A,1976,https://openlibrary.org/works/OL73385W
+Love You Forever,Robert N Munsch,N/A,1986,https://openlibrary.org/works/OL88707W
+The talisman,"Stephen King, Peter Straub",N/A,1925,https://openlibrary.org/works/OL81599W
+Modern painters,John Ruskin,N/A,1800,https://openlibrary.org/works/OL88639W
+Black Friday,James Patterson,N/A,1986,https://openlibrary.org/works/OL167147W
+Last and First Men,Olaf Stapledon,N/A,1930,https://openlibrary.org/works/OL3290731W
+Manon Lescaut,"Abbé Prévost, F. C. Green, felix crespo, Pr&eacute",N/A,1734,https://openlibrary.org/works/OL1132652W
+Computer Networks,"Andrew S. Tanenbaum, John David Wetherall, David J. Wetherall, Nickolas Feamster, David Wetherall, James F. Kurose, Keith W. Ross",N/A,1981,https://openlibrary.org/works/OL1970691W
+The Wouldbegoods,Edith Nesbit,N/A,1901,https://openlibrary.org/works/OL99543W
+Natural law in the spiritual world,Henry Drummond,N/A,1835,https://openlibrary.org/works/OL1793944W
+Clouds,Aristophanes,N/A,1715,https://openlibrary.org/works/OL20247W
+Tartuffe,Molière,N/A,1707,https://openlibrary.org/works/OL15144788W
+Messenger (The Giver #3),"Lois Lowry, David Morse, Fikret Topalli",N/A,2004,https://openlibrary.org/works/OL1846138W
+Fantastic Beasts and Where to Find Them,J. K. Rowling,N/A,2001,https://openlibrary.org/works/OL13716952W
+The Art of Racing in the Rain,Garth Stein,N/A,2008,https://openlibrary.org/works/OL2756026W
+Mademoiselle Fifi,Guy de Maupassant,N/A,1882,https://openlibrary.org/works/OL93833W
+Otoño Del Patriarca,"Gabriel García Márquez, Gregory Rabassa",N/A,1973,https://openlibrary.org/works/OL274503W
+Ostatnie Życzenie,"Andrzej Sapkowski, Danusia Stok",N/A,1993,https://openlibrary.org/works/OL2577482W
+The Path of Daggers,Robert Jordan,N/A,1998,https://openlibrary.org/works/OL1946687W
+The Rainbow Trail,Zane Grey,N/A,1914,https://openlibrary.org/works/OL485498W
+The Hero and the Crown,Robin McKinley,N/A,1984,https://openlibrary.org/works/OL109414W
+The secret of the old mill,"Franklin W. Dixon, Leslie McFarlane, Tony Carpentieri",N/A,1927,https://openlibrary.org/works/OL47910W
+Blood of the Fold,Terry Goodkind,N/A,1996,https://openlibrary.org/works/OL2010487W
+History of Alexander the Great,Jacob Abbott,N/A,1848,https://openlibrary.org/works/OL4242154W
+The Wind's Twelve Quarters,Ursula K. Le Guin,N/A,1975,https://openlibrary.org/works/OL59861W
+Eric,Terry Pratchett,N/A,1990,https://openlibrary.org/works/OL453718W
+Yellow Wallpaper Illustrated,Charlotte Perkins Gilman,N/A,2019,https://openlibrary.org/works/OL21886352W
+The Wolves of Willoughby Chase (Wolves #1),Joan Aiken,N/A,1911,https://openlibrary.org/works/OL262048W
+I Am the Messenger,Markus Zusak,N/A,2002,https://openlibrary.org/works/OL5819463W
+Sea Swept,Nora Roberts,N/A,1968,https://openlibrary.org/works/OL111479W
+Lettres persanes,"Charles-Louis de Secondat baron de La Brède et de Montesquieu, John Davidson, Carlos Cantueso",N/A,1721,https://openlibrary.org/works/OL453553W
+Sexus,Henry Miller,N/A,1949,https://openlibrary.org/works/OL261865W
+Gathering Blue,Lois Lowry,N/A,2000,https://openlibrary.org/works/OL1846069W
+The White Queen,Philippa Gregory,N/A,2009,https://openlibrary.org/works/OL59933W
+The Historian,Elizabeth Kostova,N/A,2005,https://openlibrary.org/works/OL5856511W
+Galapagos,"Kurt Vonnegut, Kurt Vonnegut, Chaim Tadmon",N/A,1820,https://openlibrary.org/works/OL98471W
+"Henley's twentieth century formulas, recipes and processes",Gardner Dexter Hiscox,N/A,1907,https://openlibrary.org/works/OL6728730W
+Before Adam,Jack London,N/A,1906,https://openlibrary.org/works/OL74501W
+Witches Abroad,Terry Pratchett,N/A,1991,https://openlibrary.org/works/OL453668W
+The Eyes of Darkness,Dean Koontz,N/A,1981,https://openlibrary.org/works/OL257746W
+Organon der rationellen Heilkunde,Samuel Hahnemann,N/A,1810,https://openlibrary.org/works/OL2101276W
+There's a Boy in the Girl's Bathroom (Cascades),Louis Sachar,N/A,1987,https://openlibrary.org/works/OL116253W
+Foundations of college chemistry,"Morris Hein, Susan Arena, Susan Arena Morris Hein",N/A,1967,https://openlibrary.org/works/OL1993999W
+Physics,Douglas C. Giancoli,N/A,1980,https://openlibrary.org/works/OL85336W
+Born in Fire,Nora Roberts,N/A,1994,https://openlibrary.org/works/OL111532W
+The Haunted Mask,Robert Lawrence Stine,N/A,1993,https://openlibrary.org/works/OL72283W
+The Tiger Who Came to Tea,Judith Kerr,N/A,1968,https://openlibrary.org/works/OL1742438W
+"Le vicomte de Bragelonne, ou, dix ans plus tard","Alexandre Dumas, Auguste Maquet",N/A,1848,https://openlibrary.org/works/OL36738W
+Tripwire,Lee Child,N/A,1999,https://openlibrary.org/works/OL52946W
+God Emperor of Dune,Frank Herbert,N/A,1981,https://openlibrary.org/works/OL893515W
+The Coming Race,"Edward Bulwer Lytton, Baron Lytton",N/A,1871,https://openlibrary.org/works/OL61825W
+The complete works of Robert Browning Volume XVI,"Robert Browning, Daniel Karlin, John Woolford",N/A,1800,https://openlibrary.org/works/OL634478W
+The Black Cat,Edgar Allan Poe,N/A,1951,https://openlibrary.org/works/OL41068W
+And the Band Played on,Randy Shilts,N/A,1987,https://openlibrary.org/works/OL3912083W
+The Bronze Bow,Elizabeth George Speare,N/A,1961,https://openlibrary.org/works/OL4783048W
+The Waste Land,T. S. Eliot,N/A,1922,https://openlibrary.org/works/OL1142292W
+The Demon-Haunted World,Carl Sagan,N/A,1995,https://openlibrary.org/works/OL2950942W
+The Golden Age,"Kenneth Grahame, Ernest H. Shepard",N/A,1879,https://openlibrary.org/works/OL69603W
+I am the Cheese,Robert Cormier,N/A,1977,https://openlibrary.org/works/OL55328W
+Godfrey of Bulloigne,"Torquato Tasso, Marzio Pieri",N/A,1581,https://openlibrary.org/works/OL502943W
+The Confession,John Grisham,N/A,2006,https://openlibrary.org/works/OL15369653W
+Fight Club,"Chuck Palahniuk, James Colby, Javier Calvo Perales, Jordi Cussà Balaguer",N/A,1996,https://openlibrary.org/works/OL18941W
+Kristy's Great Idea,Ann M. Martin,N/A,1986,https://openlibrary.org/works/OL818129W
+Just After Sunset,Stephen King,N/A,2008,https://openlibrary.org/works/OL81588W
+Fermat's Last Theorem,Simon Singh,N/A,1997,https://openlibrary.org/works/OL31155W
+The collected works of C.G. Jung,Carl Gustav Jung,N/A,1953,https://openlibrary.org/works/OL95178W
+"Der Ursprung der Familie, des Privateigenthums und des Staats",Friedrich Engels,N/A,1884,https://openlibrary.org/works/OL303640W
+My Sweet Audrina,V. C. Andrews,N/A,1982,https://openlibrary.org/works/OL134893W
+The History of the Adventures of Joseph Andrews,Henry Fielding,N/A,1742,https://openlibrary.org/works/OL45709W
+The Sirens of Titan,Kurt Vonnegut,N/A,1959,https://openlibrary.org/works/OL98485W
+Drachenreiter,Cornelia Funke,N/A,2000,https://openlibrary.org/works/OL941672W
+The Affair,Lee Child,N/A,2011,https://openlibrary.org/works/OL15942060W
+Emil und die Detektive,"Erich Kästner, KASTNER",N/A,1930,https://openlibrary.org/works/OL970122W
+Der Untergang des Abendlandes,"Oswald Spengler, Charles Francis Atkinson, Dr. David G. Payne, Charles F. Atkinson, Manuel García Morente",N/A,1918,https://openlibrary.org/works/OL3392002W
+The Year of the Flood,Margaret Atwood,N/A,2009,https://openlibrary.org/works/OL675774W
+The Associate,John Grisham,N/A,2000,https://openlibrary.org/works/OL15841562W
+L'exil et le royaume,Albert Camus,N/A,1951,https://openlibrary.org/works/OL1230611W
+The Midnight Club,James Patterson,N/A,1989,https://openlibrary.org/works/OL167181W
+The God Delusion,Richard Dawkins,N/A,2001,https://openlibrary.org/works/OL1966485W
+Salammbô,Gustave Flaubert,N/A,1863,https://openlibrary.org/works/OL893958W
+The seasons,James Thomson,N/A,1726,https://openlibrary.org/works/OL1084495W
+Musicophilia,Oliver Sacks,N/A,2007,https://openlibrary.org/works/OL277255W
+Trent's Last Case,"E. C. Bentley, E. Bentley",N/A,1913,https://openlibrary.org/works/OL1315930W
+The Paradise Mystery,Joseph Smith Fletcher,N/A,1920,https://openlibrary.org/works/OL1797752W
+Beauty,Robin McKinley,N/A,1978,https://openlibrary.org/works/OL109417W
+"1, 2, 3 to the zoo","Eric Carle, Chronicle Books Staff, Esther Rubio kokinos",N/A,1968,https://openlibrary.org/works/OL52969W
+Chto takoe iskusstvo? / What is art?,"Tolstoy, Leo, graf, 1828-1910",N/A,1898,https://openlibrary.org/works/OL15236125W
+A Hora da Estrela,Clarice Lispector,N/A,1977,https://openlibrary.org/works/OL1002120W
+Houghton Mifflin Reading Intervention,Houghton Mifflin Company Staff,N/A,2007,https://openlibrary.org/works/OL27468236W
+Peer Gynt,Henrik Ibsen,N/A,1867,https://openlibrary.org/works/OL52430W
+The Vile Village,"Lemony Snicket, Brett Helquist, Michael Kupperman",N/A,2001,https://openlibrary.org/works/OL15104130W
+Uncle Silas,Sheridan Le Fanu,N/A,1864,https://openlibrary.org/works/OL2895543W
+The Napping House (La Casa Adormecida),"Audrey Wood, Don Wood",N/A,1984,https://openlibrary.org/works/OL547418W
+South: the story of Shackleton's 1914-1917 expedition,Sir Ernest Henry Shackleton,N/A,1919,https://openlibrary.org/works/OL1931005W
+Harry the Dirty Dog,Gene Zion,N/A,1956,https://openlibrary.org/works/OL1973379W
+Tattoo Coloring Book for Adult,Dream Paris,N/A,2020,https://openlibrary.org/works/OL26640078W
+Into the Wild,Jon Krakauer,N/A,1996,https://openlibrary.org/works/OL1974546W
+The Lake House,James Patterson,N/A,1662,https://openlibrary.org/works/OL167172W
+"84, Charing Cross Road","Helene Hanff, Frank Doel, Anne Bancroft, Juliet Stevenson, Javier Calzada, Thomas Simonnet, Ruti Ḳenan",N/A,1970,https://openlibrary.org/works/OL3738761W
+Star Maker,Olaf Stapledon,N/A,1937,https://openlibrary.org/works/OL3290739W
+The Moon Pool,A. Merritt,N/A,1919,https://openlibrary.org/works/OL4104767W
+The Promise,Danielle Steel,N/A,1978,https://openlibrary.org/works/OL14873597W
+Servant of the Bones,"Anne Rice, Mariah McCourt, Renae De Liz, Ray Dillon, Michael Cumpsty",N/A,1996,https://openlibrary.org/works/OL77825W
+Quidditch Through the Ages,J. K. Rowling,N/A,2001,https://openlibrary.org/works/OL8119615W
+I Ching,"Richard Wilhelm, Cary F. Baynes, Carl Gustav Jung",N/A,1950,https://openlibrary.org/works/OL403974W
+Framley Parsonage,Anthony Trollope,N/A,1861,https://openlibrary.org/works/OL109880W
+Puck of Pook's Hill,Rudyard Kipling,N/A,1900,https://openlibrary.org/works/OL20165W
+Sofies verden,Jostein Gaarder,N/A,1991,https://openlibrary.org/works/OL922430W
+Ensaio Sobre a Cegueira,José Saramago,N/A,1995,https://openlibrary.org/works/OL27420W
+Educated,Tara Westover,N/A,2018,https://openlibrary.org/works/OL18139176W
+The white peacock,D. H. Lawrence,N/A,1911,https://openlibrary.org/works/OL81292W
+Zoya,Danielle Steel,N/A,1980,https://openlibrary.org/works/OL19771W
+Billy Budd,Herman Melville,N/A,1900,https://openlibrary.org/works/OL102746W
+All the King's Men,Robert Penn Warren,N/A,1946,https://openlibrary.org/works/OL14858283W
+The Science Fiction Hall of Fame -- Volume One,"Robert Silverberg, Robert A. Heinlein, Arthur C. Clarke, Isaac Asimov, Ray Bradbury",N/A,1970,https://openlibrary.org/works/OL1960472W
+Dead Souls,Николай Васильевич Гоголь,N/A,1942,https://openlibrary.org/works/OL17396611W
+Speak,Laurie Halse Anderson,N/A,1999,https://openlibrary.org/works/OL509183W
+The Long Goodbye,Raymond Chandler,N/A,1953,https://openlibrary.org/works/OL15400581W
+The Bone Collector (A Lincoln Rhyme Novel),Jeffery Deaver,N/A,1996,https://openlibrary.org/works/OL21732W
+Cousin Kate,Georgette Heyer,N/A,1968,https://openlibrary.org/works/OL4092674W
+Summer,Edith Wharton,N/A,1917,https://openlibrary.org/works/OL98586W
+The Blue Sword,Robin McKinley,N/A,1982,https://openlibrary.org/works/OL109416W
+The principles of psychology,William James,N/A,1890,https://openlibrary.org/works/OL1502064W
+Forever Amber,Kathleen Winsor,N/A,1944,https://openlibrary.org/works/OL100278W
+Crossroads of Twilight,Robert Jordan,N/A,1995,https://openlibrary.org/works/OL7924099W
+Le petit Nicolas,"Jean-Jacques Sempé, René Goscinny",N/A,1960,https://openlibrary.org/works/OL2383558W
+La vérité sur l'affaire Harry Quebert,Joël Dicker,N/A,2012,https://openlibrary.org/works/OL17231165W
+Emotional Intelligence,Daniel Goleman,N/A,1995,https://openlibrary.org/works/OL1878267W
+Madeline's Rescue,Ludwig Bemelmans,N/A,1900,https://openlibrary.org/works/OL1981005W
+Jabberwocky,Lewis Carroll,N/A,1881,https://openlibrary.org/works/OL151377W
+Zur Genealogie der Moral,Friedrich Nietzsche,N/A,1887,https://openlibrary.org/works/OL98169W
+Agamemnon,Aeschylus,N/A,1816,https://openlibrary.org/works/OL15464873W
+The spiffiest giant in town,Julia Donaldson,N/A,2001,https://openlibrary.org/works/OL1938270W
+Nightmares & Dreamscapes,Stephen King,N/A,1993,https://openlibrary.org/works/OL81604W
+Sadako and the Thousand Paper Cranes,Eleanor Coerr,N/A,1977,https://openlibrary.org/works/OL3506116W
+Aventures de Télémaque,François de Salignac de La Mothe-Fénelon,N/A,1699,https://openlibrary.org/works/OL781469W
+Zur psychopathologie des alltagslebens (The psychopathology of everyday life),Sigmund Freud,N/A,1904,https://openlibrary.org/works/OL1069431W
+The Reluctant Widow,Georgette Heyer,N/A,1946,https://openlibrary.org/works/OL4092660W
+The Ballad of Reading Gaol,Oscar Wilde,N/A,1896,https://openlibrary.org/works/OL8271329W
+Environmental science,"G. Tyler Miller, Scott Spoolman",N/A,1986,https://openlibrary.org/works/OL66393W
+El Juego del Ángel,Carlos Ruiz Zafón,N/A,2008,https://openlibrary.org/works/OL15165640W
+Naruto,Masashi Kishimoto,N/A,2003,https://openlibrary.org/works/OL13268171W
+The Way of the World,William Congreve,N/A,1700,https://openlibrary.org/works/OL1365156W
+Radetzkymarsch,Joseph Roth,N/A,1932,https://openlibrary.org/works/OL466942W
+The Rowan,Anne McCaffrey,N/A,1990,https://openlibrary.org/works/OL73338W
+King John,William Shakespeare,N/A,1700,https://openlibrary.org/works/OL362680W
+The Edge of the Sea,"Rachel Carson, Robert W. Hines",N/A,1955,https://openlibrary.org/works/OL1884865W
+Blue Dahlia,Nora Roberts,N/A,2004,https://openlibrary.org/works/OL111544W
+The Elite (The Selection #2),Kiera Cass,N/A,2012,https://openlibrary.org/works/OL16915199W
+The Shell Seekers,Rosamunde Pilcher,N/A,1920,https://openlibrary.org/works/OL134642W
+Histoire naturelle,"Georges-Louis Leclerc, comte de Buffon, Georges Louis Leclerc De Buffon",N/A,1749,https://openlibrary.org/works/OL1356870W
+The Eyre Affair,"Jasper Fforde, Roxane Azimi, Jasper Fforde",N/A,2001,https://openlibrary.org/works/OL5730195W
+The Relic,"Douglas Preston, Lincoln Child, Lincoln Child Douglas Preston",N/A,1995,https://openlibrary.org/works/OL8135504W
+The Quiet Gentleman,Georgette Heyer,N/A,1951,https://openlibrary.org/works/OL4092684W
+The Princess Bride,William Goldman,N/A,1973,https://openlibrary.org/works/OL486967W
+The Lilac Fairy Book (Large Print),Andrew Lang,N/A,1910,https://openlibrary.org/works/OL1088811W
+The Assistant,"Bernard Malamud, SparkNotes Staff, SparkNotes",N/A,1957,https://openlibrary.org/works/OL1937852W
+The Way of Kings,Brandon Sanderson,N/A,2010,https://openlibrary.org/works/OL15358691W
+The Black Swan,"Nassim Nicholas Taleb, David Chandler, Nassim N. Taleb",N/A,2005,https://openlibrary.org/works/OL3295030W
+The secret life of bees,"Sue Monk Kidd, Sue Kidd",N/A,2000,https://openlibrary.org/works/OL2941508W
+How the other half lives,"Jacob A. Riis, K. D. Weeks, Isabel Núñez",N/A,1890,https://openlibrary.org/works/OL1838900W
+The Feynman Lectures on Physics,Richard Phillips Feynman,N/A,1963,https://openlibrary.org/works/OL514630W
+Methuselah's children,Robert A. Heinlein,N/A,1958,https://openlibrary.org/works/OL59726W
+The Demon Lover (Chivers Sound Library),Victoria Holt,N/A,1982,https://openlibrary.org/works/OL3931405W
+The  man who would be king,Rudyard Kipling,N/A,1898,https://openlibrary.org/works/OL20112W
+Gilead,Marilynne Robinson,N/A,2004,https://openlibrary.org/works/OL1875009W
+Lord of Chaos,Robert Jordan,N/A,1994,https://openlibrary.org/works/OL7924208W
+Stone soup,Marcia Brown,N/A,1947,https://openlibrary.org/works/OL1672346W
+Sociology,John J. Macionis,N/A,1987,https://openlibrary.org/works/OL12251W
+Kiss Kiss,Roald Dahl,N/A,1960,https://openlibrary.org/works/OL45813W
+The Ghost Next Door,Robert Lawrence Stine,N/A,1993,https://openlibrary.org/works/OL72274W
+Tales of the Jazz Age,F. Scott Fitzgerald,N/A,1922,https://openlibrary.org/works/OL468479W
+Gardens of the Moon,Steven Erikson,N/A,1999,https://openlibrary.org/works/OL5734756W
+Heretics of Dune,Frank Herbert,N/A,1984,https://openlibrary.org/works/OL893502W
+Bluey,Bluey,N/A,2021,https://openlibrary.org/works/OL25332634W
+Ruby,V. C. Andrews,N/A,1900,https://openlibrary.org/works/OL134875W
+On Writing Well,William Zinsser,N/A,1976,https://openlibrary.org/works/OL2742235W
+The Stranger Beside Me,Ann Rule,N/A,1980,https://openlibrary.org/works/OL892102W
+The Struggle,Lisa Jane Smith,N/A,1991,https://openlibrary.org/works/OL277761W
+Tristan und Isolde,"Gottfried von Strassburg, Arthur Thomas Hatto, William T. Whobrey, Tomas Tomasek",N/A,1823,https://openlibrary.org/works/OL3801778W
+The Dark Prophecy,Rick Riordan,N/A,2017,https://openlibrary.org/works/OL17710050W
+Brief an den Vater,Franz Kafka,N/A,1953,https://openlibrary.org/works/OL498787W
+Freedom in exile,His Holiness Tenzin Gyatso the XIV Dalai Lama,N/A,1990,https://openlibrary.org/works/OL83715W
+The dot,Peter H. Reynolds,N/A,2003,https://openlibrary.org/works/OL2435178W
+The Light in the Forest,Conrad Richter,N/A,1953,https://openlibrary.org/works/OL1960079W
+Modesty Blaise,"O'Donnell, Peter",N/A,1965,https://openlibrary.org/works/OL3021337W
+Ajniḥah al-mutakassirah,"Kahlil Gibran, Kahil Gibran, Kahill Gibran, Kahlil Gibran",N/A,1912,https://openlibrary.org/works/OL318899W
+The color of water,James McBride,N/A,1995,https://openlibrary.org/works/OL2956952W
+Daughter of Smoke and Bone,Laini Taylor,N/A,2001,https://openlibrary.org/works/OL16103268W
+Tintenblut,Cornelia Funke,N/A,2005,https://openlibrary.org/works/OL941684W
+Cinder,Marissa Meyer,N/A,2011,https://openlibrary.org/works/OL16282945W
+The Elusive Pimpernel (Scarlet Pimpernel),"Emmuska Orczy, Baroness Orczy",N/A,1908,https://openlibrary.org/works/OL8444981W
+Calculus Made Easy,Silvanus Phillips Thompson,N/A,1914,https://openlibrary.org/works/OL1084219W
+The Invisible Life of Addie LaRue,V. E. Schwab,N/A,2015,https://openlibrary.org/works/OL20796936W
+The power-house,John Buchan,N/A,1916,https://openlibrary.org/works/OL76582W
+A People and a Nation,Mary Beth Norton,N/A,1982,https://openlibrary.org/works/OL2970876W
+How to write a play,Lajos Egri,N/A,1942,https://openlibrary.org/works/OL169844W
+Le città invisibili,Italo Calvino,N/A,1972,https://openlibrary.org/works/OL15297W
+The Psalms of David,Isaac Watts,N/A,1741,https://openlibrary.org/works/OL667198W
+El Buen Nombre (Lingua Franca),Jhumpa Lahiri,N/A,2003,https://openlibrary.org/works/OL2001056W
+The Hundred and One Dalmatians,Dodie Smith,N/A,1956,https://openlibrary.org/works/OL1518581W
+Roadwork,Stephen King,N/A,1981,https://openlibrary.org/works/OL149102W
+Winter's Heart,Robert Jordan,N/A,2000,https://openlibrary.org/works/OL7924207W
+Wüstenblume,"Waris Dirie, Cathleen Miller",N/A,1998,https://openlibrary.org/works/OL1872814W
+Sylvester and the magic pebble,William Steig,N/A,1969,https://openlibrary.org/works/OL22328W
+Countries of the World,Tomas Clancy,N/A,2012,https://openlibrary.org/works/OL33770629W
+The Teachings of Don Juan,Carlos Castaneda,N/A,1968,https://openlibrary.org/works/OL1884578W
+Water for Elephants,"Sara Gruen, David LeDoux, John Randolph Jones",N/A,2006,https://openlibrary.org/works/OL5813796W
+Iceberg,Clive Cussler,N/A,1975,https://openlibrary.org/works/OL84922W
+Chrysanthemum,Kevin Henkes,N/A,1991,https://openlibrary.org/works/OL469283W
+I sommersi e i salvati,Primo Levi,N/A,1986,https://openlibrary.org/works/OL860027W
+Play It as It Lays,Joan Didion,N/A,1970,https://openlibrary.org/works/OL500177W
+Critique of psychoanalysis,Carl Gustav Jung,N/A,1956,https://openlibrary.org/works/OL95078W
+The Emperor's New Mind,Roger Penrose,N/A,1989,https://openlibrary.org/works/OL3474169W
+Computer networking,"James F. Kurose, Keith W. Ross",N/A,1900,https://openlibrary.org/works/OL56272W
+The little minister,J. M. Barrie,N/A,1890,https://openlibrary.org/works/OL462141W
+Dirk Gently’s Holistic Detective Agency,Douglas Adams,N/A,1987,https://openlibrary.org/works/OL2163628W
+The Egypt game,Zilpha Keatley Snyder,N/A,1967,https://openlibrary.org/works/OL29899W
+The Autobiography of Alice B. Toklas,Gertrude Stein,N/A,1933,https://openlibrary.org/works/OL37277W
+A treatise of human nature,David Hume,N/A,1739,https://openlibrary.org/works/OL93569W
+The Reluctant Fundamentalist,"Mohsin Hamid, Satya Bhabha, Hamid Yoshin",N/A,2007,https://openlibrary.org/works/OL489097W
+Amelia Bedelia,"Peggy Parish, Fritz Siebel, Barbara Siebel Thomas, Wallace Tripp",N/A,1963,https://openlibrary.org/works/OL1932963W
+The Eye of Osiris,R. Austin Freeman,N/A,1911,https://openlibrary.org/works/OL13150029W
+House of a Thousand Lanterns,Victoria Holt,N/A,1940,https://openlibrary.org/works/OL3931401W
+The presentation of self in everyday life,Erving Goffman,N/A,1952,https://openlibrary.org/works/OL3282045W
+The daffodil murder,Edgar Wallace,N/A,1921,https://openlibrary.org/works/OL1517945W
+The Technique of the Mystery Story,Carolyn Wells,N/A,1913,https://openlibrary.org/works/OL1202223W
+The Man Who Fell to Earth,Walter S. Tevis,N/A,1963,https://openlibrary.org/works/OL83886W
+Fire and Ice,Erin Hunter,N/A,2003,https://openlibrary.org/works/OL5714289W
+The Cat in the Hat Comes Back,Dr. Seuss,N/A,1958,https://openlibrary.org/works/OL261147W
+"For colored girls who have considered suicide, when the rainbow is enuf",Ntozake Shange,N/A,1975,https://openlibrary.org/works/OL2180783W
+Confessions of an economic hit man,"Perkins, John, John Perkins, John Perkins, Perkins, John, 0",N/A,2004,https://openlibrary.org/works/OL2693772W
+Back To Eden,Jethro Kloss,N/A,1939,https://openlibrary.org/works/OL4658246W
+Alan Turing,Andrew Hodges,N/A,1983,https://openlibrary.org/works/OL61215W
+Echo Burning,Lee Child,N/A,2001,https://openlibrary.org/works/OL52932W
+By the King,King James VI and I,N/A,1603,https://openlibrary.org/works/OL1498776W
+"The little white bird, or, Adventures in Kensington gardens",J. M. Barrie,N/A,1902,https://openlibrary.org/works/OL461993W
+Inner Harbor,Nora Roberts,N/A,1998,https://openlibrary.org/works/OL111440W
+Assassin's Apprentice,Robin Hobb,N/A,1995,https://openlibrary.org/works/OL2707183W
+Begin Smart,Begin Smart Books,N/A,2008,https://openlibrary.org/works/OL9897484W
+The Hammer of Thor,Rick Riordan,N/A,2016,https://openlibrary.org/works/OL17860071W
+Trilby,George Du Maurier,N/A,1894,https://openlibrary.org/works/OL1940374W
+Martín Fierro,José Hernández,N/A,1894,https://openlibrary.org/works/OL8705203W
+The Double Traitor,Edward Phillips Oppenheim,N/A,1915,https://openlibrary.org/works/OL2681023W
+Nate The Great (Nate The Great),"Marjorie Weinman Sharmat, Marc Simont",N/A,1972,https://openlibrary.org/works/OL463191W
+21 Lessons for the 21st Century,"Yuval Noah Harari, Ernest Riera Arbussà",N/A,2018,https://openlibrary.org/works/OL17917961W
+Baum's American Fairy Tales,L. Frank Baum,N/A,1901,https://openlibrary.org/works/OL262341W
+The Darkest Hour,Erin Hunter,N/A,2004,https://openlibrary.org/works/OL5714310W
+FORTNITE,Epic Games,N/A,2018,https://openlibrary.org/works/OL21339253W
+The Cuckoo's Calling,J. K. Rowling,N/A,2013,https://openlibrary.org/works/OL16806416W
+The works of Robert Burns,Robert Burns,N/A,1800,https://openlibrary.org/works/OL766042W
+Tarzan the Untamed (Book #7),Edgar Rice Burroughs,N/A,1920,https://openlibrary.org/works/OL1418112W
+The Villa,Nora Roberts,N/A,2001,https://openlibrary.org/works/OL111442W
+Who Moved My Cheese?,Spencer Johnson,N/A,1998,https://openlibrary.org/works/OL1864135W
+Cryptonomicon,Neal Stephenson,N/A,1999,https://openlibrary.org/works/OL38494W
+"Island of Sheep, the","John Buchan, Harmonia Harmonia",N/A,1920,https://openlibrary.org/works/OL76506W
+The Tiger Rising,Kate DiCamillo,N/A,2001,https://openlibrary.org/works/OL468676W
+The Merry Wives of Windsor,William Shakespeare,N/A,1602,https://openlibrary.org/works/OL361595W
+English exercises adapted to Murray's English grammar,Lindley Murray,N/A,1798,https://openlibrary.org/works/OL1147648W
+The Good Guy,Dean Koontz,N/A,2007,https://openlibrary.org/works/OL263272W
+In the Night Kitchen,Maurice Sendak,N/A,1889,https://openlibrary.org/works/OL2568868W
+Barnaby Rudge,"Charles Dickens, Eileen Warren Norris",N/A,1840,https://openlibrary.org/works/OL8300174W
+"Alexander and the Terrible, Horrible, No Good, Very Bad Day","Judith Viorst, Ray Cruz",N/A,1972,https://openlibrary.org/works/OL1932036W
+Star Wars - From the Adventures of Luke Skywalker,"George Lucas, Alan Dean Foster",N/A,1976,https://openlibrary.org/works/OL61913W
+Kitchen Confidential,Anthony Bourdain,N/A,2000,https://openlibrary.org/works/OL3348011W
+The Whipping Boy,Sid Fleischman,N/A,1986,https://openlibrary.org/works/OL114726W
+The Blind Watchmaker,Richard Dawkins,N/A,1986,https://openlibrary.org/works/OL1966501W
+The Dark Forest (The Three-Body Problem Series Book 2),"刘慈欣, Joel Martinsen",N/A,2008,https://openlibrary.org/works/OL16314245W
+The Buried Giant,Kazuo Ishiguro,N/A,1900,https://openlibrary.org/works/OL17333499W
+Knife of Dreams,Robert Jordan,N/A,2005,https://openlibrary.org/works/OL7924194W
+Grendel,John Gardner,N/A,1971,https://openlibrary.org/works/OL280307W
+The inside of the cup,Winston Churchill,N/A,1913,https://openlibrary.org/works/OL18521604W
+Rising Storm,Erin Hunter,N/A,2004,https://openlibrary.org/works/OL5714301W
+The Adventures of Gerard,Arthur Conan Doyle,N/A,1902,https://openlibrary.org/works/OL262595W
+ねじまき鳥クロニクル,村上春樹,N/A,1997,https://openlibrary.org/works/OL2625412W
+The Grand Design,"Stephen Hawking, Leonard Mlodinow",N/A,1998,https://openlibrary.org/works/OL15367338W
+Advances in Imaging and Electron Physics,"Peter W. Hawkes, Martin Hÿtch",N/A,1996,https://openlibrary.org/works/OL25720424W
+The Dharma Bums,Jack Kerouac,N/A,1950,https://openlibrary.org/works/OL65897W
+Garden of Shadows,V. C. Andrews,N/A,1987,https://openlibrary.org/works/OL134888W
+K,Mary Roberts Rinehart,N/A,1915,https://openlibrary.org/works/OL137394W
+Beric the Briton,G. A. Henty,N/A,1892,https://openlibrary.org/works/OL1794485W
+Louisa May Alcott,Louisa May Alcott,N/A,1889,https://openlibrary.org/works/OL29984W
+The Talmud of Babylonia,Jacob Neusner,N/A,1984,https://openlibrary.org/works/OL30846W
+"Mister Monday (The Keys to the Kingdom, Book 1)",Garth Nix,N/A,2003,https://openlibrary.org/works/OL2628760W
+Maria Stuart,Friedrich Schiller,N/A,1801,https://openlibrary.org/works/OL207637W
+Blood Meridian,Cormac McCarthy,N/A,1985,https://openlibrary.org/works/OL40879W
+The uncommercial traveller,"Charles Dickens, Pedro Tena",N/A,1776,https://openlibrary.org/works/OL14868771W
+Dear Enemy,Jean Webster,N/A,1915,https://openlibrary.org/works/OL4322176W
+Mr. Murder,Dean Koontz,N/A,1993,https://openlibrary.org/works/OL497075W
+Pimp,"Iceberg Slim, Beck, Robert, Irvine Welsh",N/A,1967,https://openlibrary.org/works/OL1853064W
+When Breath Becomes Air,Paul Kalanithi,N/A,2016,https://openlibrary.org/works/OL17356252W
+River's End,Nora Roberts,N/A,1999,https://openlibrary.org/works/OL111471W
+The Viscount Who Loved Me,Julia Quinn,N/A,2000,https://openlibrary.org/works/OL8464993W
+City of Night,John Rechy,N/A,1963,https://openlibrary.org/works/OL61322W
+The Hunger Games Trilogy (Hunger Games / Catching Fire / Mockingjay),"Suzanne Collins, Carolyn McCormick",N/A,2010,https://openlibrary.org/works/OL15518787W
+The Pink Fairy Book,"Andrew Lang, Nora Lang, Henry Justice Ford",N/A,1897,https://openlibrary.org/works/OL1088846W
+The histories,"Polybius, Evelyn S. Shuckburgh",N/A,1542,https://openlibrary.org/works/OL5014801W
+The Stars My Destination,Alfred Bester,N/A,1956,https://openlibrary.org/works/OL1819353W
+Night Watch,Terry Pratchett,N/A,2002,https://openlibrary.org/works/OL453809W
+Stink,Megan McDonald,N/A,2001,https://openlibrary.org/works/OL104360W
+"The Capture (Guardians of Ga'Hoole, Book 1)","Kathryn Lasky, Pamela Garelick",N/A,1987,https://openlibrary.org/works/OL121844W
+The river between,Ngũgĩ wa Thiongʼo,N/A,1965,https://openlibrary.org/works/OL10246W
+The Worst Journey in the World,Apsley Cherry-Garrard,N/A,1922,https://openlibrary.org/works/OL3360211W
+Born to Run,"Christopher McDougall, Fred Sanders",N/A,2009,https://openlibrary.org/works/OL13805586W
+The Grey Fairy Book (Large Print),"Andrew Lang, H. J. 1860-1941 Ford, Henry Justice Ford",N/A,1900,https://openlibrary.org/works/OL1088798W
+Dutchman's Flat,Louis L'Amour,N/A,1979,https://openlibrary.org/works/OL50974W
+The Demolished Man,Alfred Bester,N/A,1951,https://openlibrary.org/works/OL16027965W
+The People of the Mist,H. Rider Haggard,N/A,1894,https://openlibrary.org/works/OL17536W
+The One (The Selection #3),Kiera Cass,N/A,2012,https://openlibrary.org/works/OL16925622W
+Pericles,William Shakespeare,N/A,1609,https://openlibrary.org/works/OL361665W
+The Worst Years of My Life,"James Patterson, Christopher Tebbetts",N/A,1976,https://openlibrary.org/works/OL15815082W
+The wasp factory,Iain Banks,N/A,1984,https://openlibrary.org/works/OL100784W
+The Intelligent Man's Guide to Science,Isaac Asimov,N/A,1960,https://openlibrary.org/works/OL46214W
+The kingdom of the blind,Edward Phillips Oppenheim,N/A,1909,https://openlibrary.org/works/OL241518W
+Brida,Paulo Coelho,N/A,1990,https://openlibrary.org/works/OL796480W
+The Maze of Bones,Rick Riordan,N/A,2008,https://openlibrary.org/works/OL492645W
+Apologia pro vita sua,John Henry Newman,N/A,1860,https://openlibrary.org/works/OL1144827W
+The Devil in the White City,Erik Larson,N/A,2003,https://openlibrary.org/works/OL20262W
+The Face on the Milk Carton,Caroline B. Cooney,N/A,1990,https://openlibrary.org/works/OL12388W
+The coldest winter ever,Sister Souljah,N/A,1999,https://openlibrary.org/works/OL55286W
+The First Four Years,"Laura Ingalls Wilder, Garth Williams",N/A,1953,https://openlibrary.org/works/OL1719798W
+Six of Crows,Leigh Bardugo,N/A,2015,https://openlibrary.org/works/OL17332479W
+Going Postal,Terry Pratchett,N/A,2004,https://openlibrary.org/works/OL453733W
+By the King,England and Wales. Sovereign (1625-1649 : Charles I).,N/A,1625,https://openlibrary.org/works/OL1513584W
+Finders Keepers,Stephen King,N/A,2014,https://openlibrary.org/works/OL17333186W
+Castle in the Air,Diana Wynne Jones,N/A,1990,https://openlibrary.org/works/OL60141W
+Dragonsinger,Anne McCaffrey,N/A,1977,https://openlibrary.org/works/OL73356W
+The Diamond Age,Neal Stephenson,N/A,1995,https://openlibrary.org/works/OL38499W
+Mr. Standfast,John Buchan,N/A,1919,https://openlibrary.org/works/OL76598W
+Dictionary of National Biography,"George Murray Smith, Sir Sidney Lee, Sir Leslie Stephen",N/A,1885,https://openlibrary.org/works/OL8305641W
+Lodore,Mary Shelley,N/A,1835,https://openlibrary.org/works/OL450056W
+Timon of Athens,William Shakespeare,N/A,1734,https://openlibrary.org/works/OL362223W
+Une si longue lettre,Mariama Bâ,N/A,1980,https://openlibrary.org/works/OL4672081W
+In the Hand of the Goddess,Tamora Pierce,N/A,1984,https://openlibrary.org/works/OL29250W
+Shane,Jack Schaefer,N/A,1920,https://openlibrary.org/works/OL3916716W
+The Ballad of Songbirds and Snakes,Suzanne Collins,N/A,2020,https://openlibrary.org/works/OL20716197W
+The Little White Horse,Elizabeth Goudge,N/A,1920,https://openlibrary.org/works/OL535201W
+Plays,August Strindberg,N/A,1906,https://openlibrary.org/works/OL789899W
+"Flow my tears, the policeman said",Philip K. Dick,N/A,1974,https://openlibrary.org/works/OL2172518W
+Heimskringla; Lives/Saga of the Norse Kings,Snorri Sturluson,N/A,1633,https://openlibrary.org/works/OL1133521W
+Hippolytus,"Euripides, Euripides",N/A,1756,https://openlibrary.org/works/OL66497W
+Henry And Mudge In The Sparkle Days,Cynthia Rylant,N/A,1988,https://openlibrary.org/works/OL64034W
+Quattro topi nella giungla nera,Elisabetta Dami,N/A,2003,https://openlibrary.org/works/OL8115844W
+The Eagle of the Ninth. 1400 Grundwörter.,"Rosemary Sutcliff, C. Walter Hodges",N/A,1954,https://openlibrary.org/works/OL1417723W
+The League of the Scarlet Pimpernel,"Emmuska Orczy, Baroness Orczy",N/A,1919,https://openlibrary.org/works/OL286350W
+Cyclops,"Clive Cussler, Oliver Cussler",N/A,1986,https://openlibrary.org/works/OL84916W
+ההיסטוריה של המחר,Yuval Noah Harari,N/A,2015,https://openlibrary.org/works/OL17641518W
+Mawsim al-hijrah ilá al-shamāl,"al-Ṭayyib Ṣāliḥ, Tayeb Salih, al-Ṭayyib Ṣāliḥ, Denys Johnson Davies",N/A,1969,https://openlibrary.org/works/OL2970107W
+The Greatest Salesman in the World,Og Mandino,N/A,1968,https://openlibrary.org/works/OL2642712W
+Pandora,Anne Rice,N/A,1998,https://openlibrary.org/works/OL77855W
+Chapterhouse Dune,Frank Herbert,N/A,1985,https://openlibrary.org/works/OL893508W
+Omnivore's Dilemma. A Natural History of Four Meals,"Michael Pollan, Richie Chevat, Raul Nagore",N/A,2006,https://openlibrary.org/works/OL3296483W
+Nickel and Dimed,Barbara Ehrenreich,N/A,2001,https://openlibrary.org/works/OL2520811W
+The Body,Bill Bryson,N/A,2019,https://openlibrary.org/works/OL20333471W
+На Дрини ћуприја (Na Drini ćuprija),Ivo Andrić,N/A,1956,https://openlibrary.org/works/OL258416W
+Castle Rackrent,"Maria Edgeworth, Richard Lovell Edgeworth",N/A,1800,https://openlibrary.org/works/OL1124049W
+Life of George Washington,Washington Irving,N/A,1850,https://openlibrary.org/works/OL63991W
+Naked in Death,Nora Roberts,N/A,1995,https://openlibrary.org/works/OL111460W
+The Institute,Stephen King,N/A,2019,https://openlibrary.org/works/OL20126932W
+Firefly Lane,Kristin Hannah,N/A,2008,https://openlibrary.org/works/OL488468W
+My Family and other Animals,Gerald Malcolm Durrell,N/A,1956,https://openlibrary.org/works/OL10509141W
+Fried Green Tomatoes at the Whistle Stop Cafe,Fannie Flagg,N/A,1987,https://openlibrary.org/works/OL31923W
+Jazz,Toni Morrison,N/A,1992,https://openlibrary.org/works/OL50563W
+No Orchids for Miss Blandish,James Hadley Chase,N/A,1939,https://openlibrary.org/works/OL2838607W
+Rainbow Valley,Lucy Maud Montgomery,N/A,1919,https://openlibrary.org/works/OL77756W
+The Difference Engine,"William Gibson, Bruce Sterling",N/A,1990,https://openlibrary.org/works/OL27252W
+Glory in Death,Nora Roberts,N/A,1995,https://openlibrary.org/works/OL445829W
+Thief of Time,Terry Pratchett,N/A,2001,https://openlibrary.org/works/OL453686W
+Flower Fables,Louisa May Alcott,N/A,1854,https://openlibrary.org/works/OL30056W
+The Hero of Ages,Brandon Sanderson,N/A,2008,https://openlibrary.org/works/OL5738154W
+Contemporary Nutrition,"Gordon M. Wardlaw, Anne M Smith, Paul M. Insel, Marcia F. Seyler, Angela L. Collene, Colleen K. Spees",N/A,1992,https://openlibrary.org/works/OL1853601W
+Gregor and the Prophecy of Bane,Suzanne Collins,N/A,2004,https://openlibrary.org/works/OL5735350W
+The Lemonade War,"Davies, Jacqueline",N/A,2007,https://openlibrary.org/works/OL4101318W
+The Help,Kathryn Stockett,N/A,2009,https://openlibrary.org/works/OL11999891W
+Houghton Mifflin Science,Houghton Mifflin Company Staff,N/A,2000,https://openlibrary.org/works/OL27467516W
+Borderlands/La Frontera,Gloria Anzaldúa,N/A,1987,https://openlibrary.org/works/OL61326W
+The Bear and the Dragon (Jack Ryan Novels),Tom Clancy,N/A,2000,https://openlibrary.org/works/OL159282W
+Dragonsdawn,Anne McCaffrey,N/A,1988,https://openlibrary.org/works/OL73379W
+The Prairie,James Fenimore Cooper,N/A,1800,https://openlibrary.org/works/OL77970W
+The Way Things Work,David Macaulay,N/A,1988,https://openlibrary.org/works/OL15130328W
+The Last of the Wine,Mary Renault,N/A,1956,https://openlibrary.org/works/OL3906362W
+Witch & wizard,"James Patterson, Gabrielle Charbonnet",N/A,1999,https://openlibrary.org/works/OL14920182W
+The Space Merchants,"Frederik Pohl, Cyril M. Kornbluth",N/A,1952,https://openlibrary.org/works/OL60943W
+Midnight in the Garden of Good and Evil,John Berendt,N/A,1994,https://openlibrary.org/works/OL3524935W
+Leviathan Wakes,James S. A. Corey,N/A,2009,https://openlibrary.org/works/OL16114008W
+Cycle of the Werewolf,Stephen King,N/A,1983,https://openlibrary.org/works/OL81583W
+Чайка,Антон Павлович Чехов,N/A,1915,https://openlibrary.org/works/OL55403W
+Alchemist,Ben Jonson,N/A,1965,https://openlibrary.org/works/OL29561554W
+The Ship of the Dead,Rick Riordan,N/A,2017,https://openlibrary.org/works/OL18147673W
+The atmosphere,"Frederick K. Lutgens, Edward J. Tarbuck, Redina Herman, Dennis G. Tasa, Dennis Tasa",N/A,1979,https://openlibrary.org/works/OL29602W
+The Curse of the Mummy's Tomb,Robert Lawrence Stine,N/A,1993,https://openlibrary.org/works/OL72301W
+The Clue of the Twisted Candle,Edgar Wallace,N/A,1900,https://openlibrary.org/works/OL1518059W
+The True Believer:Thoughts on the Nature of Mass Movements,"Eric Hoffer, Eric Hoffer",N/A,1951,https://openlibrary.org/works/OL927028W
+The Hot Zone,"Richard Preston, Richard Preston, Preston, Richard",N/A,1994,https://openlibrary.org/works/OL761342W
+Slippery Slope,"Lemony Snicket, Brett Helquist, Rose-Marie Vassallo",N/A,2003,https://openlibrary.org/works/OL27423194W
+Carmina,Horace,N/A,1712,https://openlibrary.org/works/OL88217W
+Kindred,"Octavia E. Butler, SparkNotes Staff",N/A,1979,https://openlibrary.org/works/OL35616W
+Caraval,Stephanie Garber,N/A,2000,https://openlibrary.org/works/OL17715454W
+Harold,"Edward Bulwer Lytton, Baron Lytton",N/A,1848,https://openlibrary.org/works/OL8088744W
+Nuclear waste,United States. General Accounting Office,N/A,1900,https://openlibrary.org/works/OL565228W
+Lays of ancient Rome,Thomas Babington Macaulay,N/A,1800,https://openlibrary.org/works/OL1237959W
+Tiger Eyes,Judy Blume,N/A,1981,https://openlibrary.org/works/OL1838370W
+The Works of Edgar Allan Poe in Five Volumes,Edgar Allan Poe,N/A,1903,https://openlibrary.org/works/OL273463W
+Verlorene Ehre der Katharina Blum,Heinrich Böll,N/A,1974,https://openlibrary.org/works/OL15394878W
+Lyddie,Katherine Paterson,N/A,1991,https://openlibrary.org/works/OL17734700W
+The Bat,Mary Roberts Rinehart,N/A,1926,https://openlibrary.org/works/OL137388W
+Mossflower,Brian Jacques,N/A,1988,https://openlibrary.org/works/OL25672716W
+The Miraculous Journey of Edward Tulane,Kate DiCamillo,N/A,2000,https://openlibrary.org/works/OL468661W
+The Principles of Scientific Management,Frederick Winslow Taylor,N/A,1911,https://openlibrary.org/works/OL1866671W
+The Emperor of All Maladies,"Siddhartha Mukherjee, Nessa Carey",N/A,2010,https://openlibrary.org/works/OL15540668W
+Winnie-the-Pooh and Some Bees,A. A. Milne,N/A,1975,https://openlibrary.org/works/OL14954371W
+Dog Man,Dav Pilkey,N/A,2015,https://openlibrary.org/works/OL17610986W
+"Vector Mechanics for Engineers, Statics & Dynamics","Ferdinand Pierre Beer, E. Russell Johnston, Jr., William E. Clausen, George Staab, Elliot R. Eisenberg, David Mazurek, Phillip J. Cornwell, Brian Self",N/A,1962,https://openlibrary.org/works/OL279741W
+Le chevalier de Maison-Rouge,"Alexandre Dumas, Auguste Maquet",N/A,1840,https://openlibrary.org/works/OL36775W
+Anne Hooper's pocket Kama Sutra,"Anne Hooper, Ulrike Kerstiens",N/A,1994,https://openlibrary.org/works/OL1698246W
+Cause of Death,Patricia Cornwell,N/A,1995,https://openlibrary.org/works/OL263809W
+Ender's Shadow,Orson Scott Card,N/A,1999,https://openlibrary.org/works/OL49496W
+Historia ecclesiastica gentis Anglorum,Saint Bede the Venerable,N/A,1475,https://openlibrary.org/works/OL1322922W
+A House for Hermit Crab,Eric Carle,N/A,1987,https://openlibrary.org/works/OL52973W
+Flow,Mihaly Csikszentmihalyi,N/A,1990,https://openlibrary.org/works/OL278571W
+A strange manuscript found in a copper cylinder,James De Mille,N/A,1888,https://openlibrary.org/works/OL96167W
+The Boy Who Harnessed the Wind,"William Kamkwamba, Bryan Mealer, Korey Jackson",N/A,2009,https://openlibrary.org/works/OL15190422W
+Merrick,Anne Rice,N/A,2000,https://openlibrary.org/works/OL77848W
+Aphrodite (ancient manners),"Pierre Louÿs, Jean-Paul Goujon, Prepared by Pierre Louys; Willis L. Parker, Georges Bess, Milo Manara",N/A,1848,https://openlibrary.org/works/OL1237227W
+Darkness Comes,Dean Koontz,N/A,1984,https://openlibrary.org/works/OL263267W
+A Fine Balance,Rohinton Mistry,N/A,1995,https://openlibrary.org/works/OL2980902W
+Southern Horrors,"Ida B. Wells-Barnett, I. Garland Penn, T. Thomas Fortune",N/A,1892,https://openlibrary.org/works/OL21963355W
+Web of Dreams,V. C. Andrews,N/A,1920,https://openlibrary.org/works/OL134878W
+Trainspotting,Irvine Welsh,N/A,1993,https://openlibrary.org/works/OL816259W
+Notes of a Native Son,James Baldwin,N/A,1955,https://openlibrary.org/works/OL2683365W
+Just Kids,"Patti Smith, Patti Smith, Héloïse Esquié",N/A,2006,https://openlibrary.org/works/OL15474046W
+The history of British India,"H. H. Wilson, James Mill",N/A,1817,https://openlibrary.org/works/OL68023W
+Adolphe,"Benjamin Constant, B. Constant, Benjamin Constant, Harold Nicolson, Carl Wildman",N/A,1816,https://openlibrary.org/works/OL55151W
+Novelas ejemplares,Miguel de Cervantes Saavedra,N/A,1626,https://openlibrary.org/works/OL273392W
+Nineteen Minutes,Jodi Picoult,N/A,2006,https://openlibrary.org/works/OL891945W
+2061,Arthur C. Clarke,N/A,1987,https://openlibrary.org/works/OL17408W
+Valley of the dolls,Jacqueline Susann,N/A,1966,https://openlibrary.org/works/OL2659139W
+Die Vermessung der Welt,Daniel Kehlmann,N/A,2005,https://openlibrary.org/works/OL991411W
+The Curse of Chalion,Lois McMaster Bujold,N/A,1991,https://openlibrary.org/works/OL56910W
+The Little Friend (The Little Friend),Donna Tartt,N/A,2000,https://openlibrary.org/works/OL4321136W
+Dark Witch,Nora Roberts,N/A,2013,https://openlibrary.org/works/OL17116778W
+The Black Moth,Georgette Heyer,N/A,1921,https://openlibrary.org/works/OL4092663W
+Essential Cell Biology,"Bruce Alberts, Dennis Bray, Karen Hopkin, Alexander D Johnson, Julian Lewis, Martin Raff, Keith Roberts, Peter Walter",N/A,1997,https://openlibrary.org/works/OL7938487W
+Hornblower in the West Indies,C. S. Forester,N/A,1958,https://openlibrary.org/works/OL1937776W
+Gift from the sea,Anne Morrow Lindbergh,N/A,1955,https://openlibrary.org/works/OL3014037W
+"How I Made $2,000,000 In The Stock Market",Nicolas Darvas,N/A,1960,https://openlibrary.org/works/OL6662939W
+The Invasion,Katherine Applegate,N/A,1996,https://openlibrary.org/works/OL8115287W
+The gift of the Magi,O. Henry,N/A,1906,https://openlibrary.org/works/OL181953W
+The Cay,Theodore Taylor,N/A,1969,https://openlibrary.org/works/OL270974W
+Born in Ice,Nora Roberts,N/A,1995,https://openlibrary.org/works/OL111604W
+Mindhunter,"John E. Douglas, Mark Olshaker",N/A,1995,https://openlibrary.org/works/OL119421W
+The Lorax,Dr. Seuss,N/A,1911,https://openlibrary.org/works/OL261155W
+Pawn of Prophecy,David Eddings,N/A,1982,https://openlibrary.org/works/OL1922990W
+Molecular biology of the gene,"James D. Watson, Nancy H. Hopkins, Jeffrey W. Roberts, Joan Argetsinger Steitz, Alan M. Weiner",N/A,1965,https://openlibrary.org/works/OL222777W
+The Power,Naomi Alderman,N/A,1998,https://openlibrary.org/works/OL17607742W
+Frenchman's Creek,Daphne du Maurier,N/A,1940,https://openlibrary.org/works/OL7917284W
+El amante japonés,Isabel Allende,N/A,2000,https://openlibrary.org/works/OL17357601W
+First thing first,"Stephen R. Covey, A. Roger Merrill, Rebecca R. Merrill",N/A,1994,https://openlibrary.org/works/OL2629998W
+Psychology,"Carole Wade, Carol Tavris",N/A,1987,https://openlibrary.org/works/OL15844725W
+Pacific Vortex!,Clive Cussler,N/A,1982,https://openlibrary.org/works/OL84905W
+Rinkitink in Oz,L. Frank Baum,N/A,1916,https://openlibrary.org/works/OL262376W
+"Oh, the Places You'll Go!",Dr. Seuss,N/A,1990,https://openlibrary.org/works/OL261196W
+The Hostile Hospital,"Lemony Snicket, Brett Helquist, Michael Kupperman",N/A,2001,https://openlibrary.org/works/OL15104028W
+Shadow of the Hegemon,Orson Scott Card,N/A,2001,https://openlibrary.org/works/OL49564W
+A Fire upon the Deep,Vernor Vinge,N/A,1992,https://openlibrary.org/works/OL1975714W
+Luftslottet som sprängdes,Stieg Larsson,N/A,2007,https://openlibrary.org/works/OL14909364W
+The Woman Who Rides Like a Man,Tamora Pierce,N/A,1986,https://openlibrary.org/works/OL29282W
+Development through the lifespan,Laura E. Berk,N/A,1998,https://openlibrary.org/works/OL14471W
+Shadow and Bone,Leigh Bardugo,N/A,2012,https://openlibrary.org/works/OL16239519W
+Sozialgeschichte der Kunst und Literatur,"Arnold Hauser, S. Godman, Harris, Jonathan, Jonathan Harris",N/A,1951,https://openlibrary.org/works/OL1331984W
+The Immortal Life of Henrietta Lacks,Rebecca Skloot,N/A,2009,https://openlibrary.org/works/OL13850788W
+Là-bas,Joris-Karl Huysmans,N/A,1890,https://openlibrary.org/works/OL2239400W
+Astoria,Washington Irving,N/A,1800,https://openlibrary.org/works/OL63862W
+The Refugees,Arthur Conan Doyle,N/A,1891,https://openlibrary.org/works/OL262591W
+Opera,Publius Vergilius Maro,N/A,1502,https://openlibrary.org/works/OL13086557W
+Dinner at the Homesick Restaurant,Anne Tyler,N/A,1982,https://openlibrary.org/works/OL28279W
+Fat is a feminist issue,"Susie Orbach, S ORBACH, Susie Orbach        , Susie Orbach",N/A,1978,https://openlibrary.org/works/OL508163W
+Flickan som lekte med elden,Stieg Larsson,N/A,2006,https://openlibrary.org/works/OL5784621W
+The Tragical History of the Life and Death of Doctor Faustus,Christopher Marlowe,N/A,1609,https://openlibrary.org/works/OL45714W
+The Chimes,"Charles Dickens, Richard Doyle, William Clarkson Stanfield, Sajad Hussain, Oscar Ellis, Michael Clay Thompson",N/A,1800,https://openlibrary.org/works/OL14868619W
+The Terror,Dan Simmons,N/A,2007,https://openlibrary.org/works/OL1963316W
+The Wise Man’s Fear,Patrick Rothfuss,N/A,2011,https://openlibrary.org/works/OL8479869W
+The Carnivorous Carnival,"Lemony Snicket, Brett Helquist, Michael Kupperman",N/A,2002,https://openlibrary.org/works/OL15104132W
+Pretties,Scott Westerfeld,N/A,2005,https://openlibrary.org/works/OL547147W
+2020-2021,Love Write,N/A,2020,https://openlibrary.org/works/OL27246073W
+Letters on demonology and witchcraft,Sir Walter Scott,N/A,1830,https://openlibrary.org/works/OL863779W
+A Prayer for Owen Meany,John Irving,N/A,1989,https://openlibrary.org/works/OL14858723W
+Penultimate Peril,"Lemony Snicket, Brett Helquist, Michael Kupperman, Rose-Marie Vassallo-Villaneau",N/A,2005,https://openlibrary.org/works/OL26500589W
+The city in history,"Lewis Mumford, MANG FU DE (Mumford Lewis)",N/A,1961,https://openlibrary.org/works/OL1879188W
+Yogasūtra,Patañjali.,N/A,1890,https://openlibrary.org/works/OL300151W
+Wir Kinder vom Bahnhof Zoo,"Christiane Felscherinow, Kai Hermann, Horst Rieck, Sonja Vukovic",N/A,1978,https://openlibrary.org/works/OL8368141W
+The Three Little Pigs,James Orchard Halliwell-Phillipps,N/A,1962,https://openlibrary.org/works/OL265468W
+Tristes Tropiques,"Claude Lévi-Strauss, Wang zhi ming",N/A,1955,https://openlibrary.org/works/OL8261409W
+Dragons of Autumn Twilight,"Margaret Weis, Tracy Hickman, Paul Boehmer, Andrew Dabb, Steve Kurth, Stefano Raffaele, Margarett Weiss",N/A,1984,https://openlibrary.org/works/OL73410W
+The Queen's gambit,Walter S. Tevis,N/A,1983,https://openlibrary.org/works/OL83884W
+Quatrevingt-treize,Victor Hugo,N/A,1800,https://openlibrary.org/works/OL15202029W
+The Shivering Sands,Victoria Holt,N/A,1750,https://openlibrary.org/works/OL3453399W
+The Blue Fairy Book,"Andrew Lang, Henry Justice Ford, G. P. Jacomb Hood, H. Ford, P. Hood",N/A,1889,https://openlibrary.org/works/OL1088770W
+Mattimeo (Redwall #3),"Brian Jacques, Brajan Dzhejks",N/A,1989,https://openlibrary.org/works/OL25672713W
+Doctor Thorne,Anthony Trollope,N/A,1858,https://openlibrary.org/works/OL109881W
+The Abolition of Man,C.S. Lewis,N/A,1943,https://openlibrary.org/works/OL71117W
+Dark Places,Gillian Flynn,N/A,2009,https://openlibrary.org/works/OL5842017W
+Suite française,Irène Némirovsky,N/A,2004,https://openlibrary.org/works/OL1308096W
+Meditations and contemplations,James Hervey,N/A,1748,https://openlibrary.org/works/OL1137831W
+How we think,John Dewey,N/A,1909,https://openlibrary.org/works/OL111357W
+One of Ours,Willa Cather,N/A,1922,https://openlibrary.org/works/OL12830W
+The Sea-Hawk,Rafael Sabatini,N/A,1900,https://openlibrary.org/works/OL8070951W
+Private,"James Patterson, Maxine Paetro",N/A,2008,https://openlibrary.org/works/OL14920152W
+All Creatures Great and Small (All Creatures Great and Small #1-2),James Herriot,N/A,1972,https://openlibrary.org/works/OL42308W
+The Hour of the Dragon,Robert E. Howard,N/A,1977,https://openlibrary.org/works/OL2848500W
+Little Birds,Anaïs Nin,N/A,1979,https://openlibrary.org/works/OL278313W
+The Summer of the Swans,Betsy Cromer Byars,N/A,1970,https://openlibrary.org/works/OL279226W
+The Tell-Tale Heart,Edgar Allan Poe,N/A,1976,https://openlibrary.org/works/OL41059W
+The Testaments,Margaret Atwood,N/A,2019,https://openlibrary.org/works/OL20129837W
+Dragondrums,Anne McCaffrey,N/A,1979,https://openlibrary.org/works/OL73375W
+The Blank Slate,"Steven Pinker, Victor Bevine, Roc Filella Escolà, ʻImanuʾel Loṭem",N/A,2002,https://openlibrary.org/works/OL477826W
+It's Not the End of the World,Judy Blume,N/A,1970,https://openlibrary.org/works/OL1838410W
+Being Mortal,Atul Gawande,N/A,2014,https://openlibrary.org/works/OL17079567W
+Sketches by Boz,"Charles Dickens, Marcus Stone, George Cruikshank",N/A,1800,https://openlibrary.org/works/OL8721464W
+The Black Box,Edward Phillips Oppenheim,N/A,1915,https://openlibrary.org/works/OL2681008W
+Il Codice del Drago,Elisabetta Dami,N/A,2005,https://openlibrary.org/works/OL15168089W
+The Golem's Eye,Jonathan Stroud,N/A,2004,https://openlibrary.org/works/OL85678W
+The Looming Tower,Lawrence Wright,N/A,2006,https://openlibrary.org/works/OL193645W
+Cape Cod,Henry David Thoreau,N/A,1864,https://openlibrary.org/works/OL55724W
+Elizabeth and Her German Garden,"Elizabeth von Arnim, Ulrich Baer",N/A,1898,https://openlibrary.org/works/OL1972840W
+Fate Is the Hunter,Ernest K. Gann,N/A,1961,https://openlibrary.org/works/OL4416196W
+The Truth,"Terry Pratchett, Stephen Briggs",N/A,1995,https://openlibrary.org/works/OL453693W
+The Summer I Turned Pretty,Jenny Han,N/A,2000,https://openlibrary.org/works/OL5819962W
+The Black Stallion,Walter Farley,N/A,1941,https://openlibrary.org/works/OL869965W
+Escape from Freedom,Erich Fromm,N/A,1941,https://openlibrary.org/works/OL1184906W
+Blood and Gold,Anne Rice,N/A,1998,https://openlibrary.org/works/OL77795W
+The Image of the City,Kevin Lynch,N/A,1960,https://openlibrary.org/works/OL4477193W
+The Best of Me,Nicholas Sparks,N/A,2011,https://openlibrary.org/works/OL15729059W
+La Nuit du Titanic,Walter Lord,N/A,1955,https://openlibrary.org/works/OL1843658W
+Il Fantasma del Metrò,Elisabetta Dami,N/A,2000,https://openlibrary.org/works/OL8115828W
+A Kiss Before Dying,Ira Levin,N/A,1953,https://openlibrary.org/works/OL28321W
+Doodle Art,Doodle Art,N/A,1991,https://openlibrary.org/works/OL9280200W
+Calculus,James Stewart,N/A,1986,https://openlibrary.org/works/OL100903W
+This Present Darkness,Frank E. Peretti,N/A,1986,https://openlibrary.org/works/OL26292665W
+Chinese Cinderella,Adeline Yen Mah,N/A,1999,https://openlibrary.org/works/OL121492W
+His Dark Materials,Philip Pullman,N/A,2000,https://openlibrary.org/works/OL28986W
+Os Maias,Eça de Queiroz,N/A,1900,https://openlibrary.org/works/OL846513W
+Tattoo Coloring Book,Jenny Olsen,N/A,2020,https://openlibrary.org/works/OL26640082W
+A history of the modern world,"R. R. Palmer, Palmer, Joel G. Colton",N/A,1950,https://openlibrary.org/works/OL3477033W
+Love for Love,William Congreve,N/A,1695,https://openlibrary.org/works/OL1365176W
+Eugenics and Other Evils,Gilbert Keith Chesterton,N/A,1922,https://openlibrary.org/works/OL76446W
+The mists of Avalon,Marion Zimmer Bradley,N/A,1979,https://openlibrary.org/works/OL23793W
+La Mort heureuse,Albert Camus,N/A,1971,https://openlibrary.org/works/OL1230571W
+Demon Seed,Dean Koontz,N/A,1973,https://openlibrary.org/works/OL263284W
+The Whistler,John Grisham,N/A,2016,https://openlibrary.org/works/OL17846634W
+The Maine Woods,Henry David Thoreau,N/A,1803,https://openlibrary.org/works/OL55721W
+The Life of Charlotte Bronte,Elizabeth Cleghorn Gaskell,N/A,1857,https://openlibrary.org/works/OL1103197W
+Otto of the Silver Hand,"Howard Pyle, Howard Pyle",N/A,1888,https://openlibrary.org/works/OL2021957W
+The plays of Oscar Wilde,Oscar Wilde,N/A,1905,https://openlibrary.org/works/OL14877434W
+The Power of Now,Eckhart Tolle,N/A,1997,https://openlibrary.org/works/OL5727686W
+Чернобыльская молитва,Светлана Алексиевич,N/A,1997,https://openlibrary.org/works/OL1725867W
+Henry and Mudge,Cynthia Rylant,N/A,1987,https://openlibrary.org/works/OL64169W
+Where the Sidewalk Ends,Shel Silverstein,N/A,1974,https://openlibrary.org/works/OL3368289W
+The complete economy of human life,"Robert Dodsley, John Hill, Hill, John, Philip Dormer Stanhope, 4th Earl of Chesterfield",N/A,1750,https://openlibrary.org/works/OL1064881W
+The Fall of Hyperion,Dan Simmons,N/A,1990,https://openlibrary.org/works/OL1963251W
+Adam Bede,George Eliot,N/A,1859,https://openlibrary.org/works/OL20935W
+Keeper of the Lost Cities,Shannon Messenger,N/A,2012,https://openlibrary.org/works/OL16361049W
+Geography,"Harm J. de Blij, Peter O. Muller",N/A,1971,https://openlibrary.org/works/OL1942105W
+Enten-eller,Søren Kierkegaard,N/A,1843,https://openlibrary.org/works/OL112738W
+Se una notte d'inverno un viaggiatore,Italo Calvino,N/A,1979,https://openlibrary.org/works/OL15321W
+JavaScript,David Flanagan,N/A,1996,https://openlibrary.org/works/OL1643770W
+Death's End (The Three-Body Problem Series Book 3),刘慈欣,N/A,2010,https://openlibrary.org/works/OL17610507W
+Hoot,Carl Hiaasen,N/A,2002,https://openlibrary.org/works/OL463581W
+The Boys in the Boat,Daniel James Brown,N/A,2013,https://openlibrary.org/works/OL17038299W
+A Dangerous Path,Erin Hunter,N/A,2004,https://openlibrary.org/works/OL5714284W
+Paradise Lost,John Milton,N/A,2017,https://openlibrary.org/works/OL29609413W
+Dictionary of Daily Life in Biblical and Post-Biblical Antiquity,"Edwin M. Yamauchi, Wilson, Marvin R.",N/A,2016,https://openlibrary.org/works/OL25702285W
+Atlantis Found,Clive Cussler,N/A,1999,https://openlibrary.org/works/OL84866W
+The After House,Mary Roberts Rinehart,N/A,1914,https://openlibrary.org/works/OL137397W
+The Thief of Always,Clive Barker,N/A,1992,https://openlibrary.org/works/OL257791W
+Mars and Venus in the bedroom,John Gray,N/A,1995,https://openlibrary.org/works/OL1965529W
+Conversación en La Catedral,Mario Vargas Llosa,N/A,1969,https://openlibrary.org/works/OL857552W
+Men in Love: Men's Sexual Fantasies,Nancy Friday,N/A,1980,https://openlibrary.org/works/OL733143W
+Frederica,Georgette Heyer,N/A,1965,https://openlibrary.org/works/OL4092648W
+Wild Magic,Tamora Pierce,N/A,1992,https://openlibrary.org/works/OL29261W
+The Cement Garden,Ian McEwan,N/A,1978,https://openlibrary.org/works/OL1855884W
+Paul et Virginie,Bernardin de Saint-Pierre,N/A,1789,https://openlibrary.org/works/OL1077449W
+The Beasts of Tarzan,Edgar Rice Burroughs,N/A,1916,https://openlibrary.org/works/OL1418146W
+How Do Dinosaurs Say Good Night?,Jane Yolen,N/A,2000,https://openlibrary.org/works/OL15161074W
+Sea Tales,James Fenimore Cooper,N/A,1823,https://openlibrary.org/works/OL77972W
+Criminology,Larry J. Siegel,N/A,1983,https://openlibrary.org/works/OL2692628W
+Czas pogardy,Andrzej Sapkowski,N/A,1995,https://openlibrary.org/works/OL2577481W
+Claudia and Mean Janine,Ann M. Martin,N/A,1987,https://openlibrary.org/works/OL817957W
+Far away and long ago,W. H. Hudson,N/A,1918,https://openlibrary.org/works/OL879152W
+Postern of Fate,Agatha Christie,N/A,1973,https://openlibrary.org/works/OL471907W
+Acres of diamonds,"Russell Herman Conwell, Robert Shackleton - undifferentiated, John Wanamaker, Robert Collier, John Wanamaker",N/A,1901,https://openlibrary.org/works/OL3920712W
+The Claiming of Sleeping Beauty,Anne Rice,N/A,1983,https://openlibrary.org/works/OL77834W
+Klara and the Sun,Kazuo Ishiguro,N/A,2019,https://openlibrary.org/works/OL20883297W
+Lore Olympus,Rachel Smythe,N/A,2021,https://openlibrary.org/works/OL24219093W
+The Women Of Brewster Place,Gloria Naylor,N/A,1982,https://openlibrary.org/works/OL134420W
+The Haunted House,"Charles Dickens, Elizabeth Cleghorn Gaskell",N/A,1859,https://openlibrary.org/works/OL14869112W
+The Silent Patient,Alex Michaelides,N/A,2018,https://openlibrary.org/works/OL19096402W
+The pigman,Paul Zindel,N/A,1968,https://openlibrary.org/works/OL15839090W
+Sprig Muslin,Georgette Heyer,N/A,1956,https://openlibrary.org/works/OL4092690W
+The Raven Boys,Maggie Stiefvater,N/A,2012,https://openlibrary.org/works/OL17557879W
+Dancer from the Dance,Andrew Holleran,N/A,1978,https://openlibrary.org/works/OL79305W
+The Code Book,Simon Singh,N/A,1999,https://openlibrary.org/works/OL31157W
+The 7 Habits of Highly Effective Teens,"Sean Covey, Stephen R. Covey",N/A,1998,https://openlibrary.org/works/OL482313W
+The Unknown Ajax,Georgette Heyer,N/A,1959,https://openlibrary.org/works/OL4092673W
+Journey Under The Sea,R. A. Montgomery,N/A,1977,https://openlibrary.org/works/OL2928243W
+Influence,Robert B. Cialdini,N/A,1983,https://openlibrary.org/works/OL3902892W
+The Soul of a New Machine,Tracy Kidder,N/A,1981,https://openlibrary.org/works/OL98218W
+Chicka chicka boom boom,"Bill Martin Jr., John Archambault",N/A,1989,https://openlibrary.org/works/OL59121W
+The Magic School Bus,Joanna Cole,N/A,1994,https://openlibrary.org/works/OL83104W
+The Moviegoer,Walker Percy,N/A,1961,https://openlibrary.org/works/OL38282W
+Sodome et Gomorrhe,Marcel Proust,N/A,1919,https://openlibrary.org/works/OL1190284W
+Anansi the Spider,Gerald McDermott,N/A,1972,https://openlibrary.org/works/OL2009972W
+The Colorado Kid,Stephen King,N/A,1978,https://openlibrary.org/works/OL149171W
+Snuff,Terry Pratchett,N/A,2011,https://openlibrary.org/works/OL16123737W
+The Curse of Capistrano,Johnston McCulley,N/A,1924,https://openlibrary.org/works/OL5846465W
+Ronja rövardotter,Astrid Lindgren,N/A,1981,https://openlibrary.org/works/OL14872976W
+Joyland,"Stephen King, Michael Kelly.",N/A,2011,https://openlibrary.org/works/OL16806826W
+A single shard,Linda Sue Park,N/A,2001,https://openlibrary.org/works/OL41691W
+Monster,Walter Dean Myers,N/A,1999,https://openlibrary.org/works/OL98288W
+The English Tongue,"Thomas Dilworth, J. Duick, Thomas Ken, Samuel Gore, Alexander Pope, P. I. Zhdanov, James Poupard",N/A,1740,https://openlibrary.org/works/OL1651333W
+The Sight,Erin Hunter,N/A,2007,https://openlibrary.org/works/OL5714304W
+Blink,Malcolm Gladwell,N/A,2004,https://openlibrary.org/works/OL5749849W
+Percy Jackson's Greek Gods,Rick Riordan,N/A,2006,https://openlibrary.org/works/OL17054790W
+The Ship Who Sang,Anne McCaffrey,N/A,1969,https://openlibrary.org/works/OL73367W
+Children of the Frost,Jack London,N/A,1800,https://openlibrary.org/works/OL144813W
+Decline and Fall,Evelyn Waugh,N/A,1928,https://openlibrary.org/works/OL5721413W
+The millionaire next door,"Thomas J. Stanley, William D. Danko",N/A,1996,https://openlibrary.org/works/OL1986060W
+Throne of Glass,Sarah J. Maas,N/A,2012,https://openlibrary.org/works/OL16607146W
+"Zuleika Dobson, or, An Oxford love story",Sir Max Beerbohm,N/A,1911,https://openlibrary.org/works/OL767580W
+A Gentleman in Moscow,Amor Towles,N/A,2016,https://openlibrary.org/works/OL17797130W
+The Tattooist of Auschwitz: the heart-breaking and unforgettable international bestseller,"Heather Morris, Heather Morris, Morris, Heather teacher., Morris Heather, Sarah Fields",N/A,2018,https://openlibrary.org/works/OL19661009W
+Turtles All the Way Down,John Green,N/A,2017,https://openlibrary.org/works/OL17842319W
+The Lost Heir,Tui T. Sutherland,N/A,2012,https://openlibrary.org/works/OL17423096W
+More Scary Stories to Tell in the Dark,"Alvin Schwartz, Alvin  Schwartz",N/A,1605,https://openlibrary.org/works/OL273693W
+The Enchantress Returns,Chris Colfer,N/A,2013,https://openlibrary.org/works/OL17262607W
+The Burning Maze,Rick Riordan,N/A,2018,https://openlibrary.org/works/OL17868260W
+100 Animals,Scott Autumn,N/A,2020,https://openlibrary.org/works/OL26956741W
+Harold and the Purple Crayon,Crockett Johnson,N/A,1955,https://openlibrary.org/works/OL3544186W
+The theory of everything,Stephen Hawking,N/A,2002,https://openlibrary.org/works/OL1892616W
+Georgica,Publius Vergilius Maro,N/A,1523,https://openlibrary.org/works/OL47147W
+Tipping the Velvet,Sarah Waters,N/A,1998,https://openlibrary.org/works/OL551012W
+The study of language,"George Yule, George Yule",N/A,1985,https://openlibrary.org/works/OL1390239W
+Anti-intellectualism in American life,"Richard Hofstadter, Richard Hofstadter, Adam Verner, Richard Hofstader",N/A,1963,https://openlibrary.org/works/OL16445795W
+Welcome to Camp Nightmare,Robert Lawrence Stine,N/A,1993,https://openlibrary.org/works/OL72351W
+3rd Degree,"James Patterson, Andrew Gross",N/A,2004,https://openlibrary.org/works/OL167144W
+"The octopus, a story of California",Frank Norris,N/A,1901,https://openlibrary.org/works/OL1794917W
+Clouds of Witness,Dorothy L. Sayers,N/A,1926,https://openlibrary.org/works/OL2234815W
+Why mosquitoes buzz in people's ears,Verna Aardema,N/A,1975,https://openlibrary.org/works/OL2654553W
+Dr. Seuss's ABC,Dr. Seuss,N/A,1960,https://openlibrary.org/works/OL261152W
+King of Shadows,Susan Cooper,N/A,1999,https://openlibrary.org/works/OL894226W
+The City & The City,"China Miéville, China Miéville",N/A,2009,https://openlibrary.org/works/OL14873309W
+Seven Pillars of Wisdom,T. E. Lawrence,N/A,1905,https://openlibrary.org/works/OL830503W
+The devil's arithmetic,Jane Yolen,N/A,1988,https://openlibrary.org/works/OL97262W
+The Alloy of Law,Brandon Sanderson,N/A,2001,https://openlibrary.org/works/OL16597059W
+Lean In,"Sheryl Sandberg, Nell Scovell",N/A,1799,https://openlibrary.org/works/OL16802331W
+The fabric of the cosmos,"Brian Greene, Javier García Sanz",N/A,2004,https://openlibrary.org/works/OL1909291W
+Making Money,Terry Pratchett,N/A,2007,https://openlibrary.org/works/OL453907W
+Fables,Arnold Lobel,N/A,1980,https://openlibrary.org/works/OL1973398W
+"Rich Dad, Poor Dad for Teens","Robert T. Kiyosaki, Sharon L. Lechter",N/A,2004,https://openlibrary.org/works/OL2010893W
+Historia verdadera de la conquista de la Nueva España,Bernal Díaz del Castillo,N/A,1632,https://openlibrary.org/works/OL2974718W
+The Denial of Death,"Ernest Becker, Ernest Becker",N/A,1973,https://openlibrary.org/works/OL154572W
+The Werewolf of Fever Swamp,Robert Lawrence Stine,N/A,1993,https://openlibrary.org/works/OL72430W
+Vampire Breath,Robert Lawrence Stine,N/A,1996,https://openlibrary.org/works/OL72404W
+Autobiography of an Ex-Colored Man,James Weldon Johnson,N/A,1900,https://openlibrary.org/works/OL37208W
+The desert of the heart,Jane Rule,N/A,1964,https://openlibrary.org/works/OL4797022W
+Runaway,Alice Munro,N/A,2004,https://openlibrary.org/works/OL931680W
+"Mary, Mary",James Patterson,N/A,1857,https://openlibrary.org/works/OL167173W
+"Gödel, Escher, Bach",Douglas R. Hofstadter,N/A,1979,https://openlibrary.org/works/OL716850W
+The Looking Glass War,John le Carré,N/A,1965,https://openlibrary.org/works/OL15723138W
+Tales of space and time,H. G. Wells,N/A,1899,https://openlibrary.org/works/OL52211W
+Fasti,Ovid,N/A,1482,https://openlibrary.org/works/OL97775W
+King Henry VI. Part 2,William Shakespeare,N/A,1600,https://openlibrary.org/works/OL258709W
+Corporate finance,"Jonathan B. Berk, Jonathan Berk, Peter DeMarzo",N/A,2006,https://openlibrary.org/works/OL5890331W
+Stiff,"Mary Roach, M Roach, Shelly Frasier, Mary Roach",N/A,2003,https://openlibrary.org/works/OL7986135W
+Sartor resartus,Thomas Carlyle,N/A,1800,https://openlibrary.org/works/OL1064699W
+The player of games,Iain Banks,N/A,1988,https://openlibrary.org/works/OL100779W
+The Dragonet Prophecy,Tui T. Sutherland,N/A,2012,https://openlibrary.org/works/OL27696982W
+Touching the void,"Joe Simpson, Joe Simpson",N/A,1988,https://openlibrary.org/works/OL11616538W
+The Great Influenza,"John M. Barry, Amelia Pérez de Villlar, John M. Barry",N/A,2004,https://openlibrary.org/works/OL7989229W
+The Death Cure,"James Dashner, James Dashner",N/A,2011,https://openlibrary.org/works/OL16099103W
+Rosencrantz & Guildenstern are dead,"Tom Stoppard, Fay Kanin, Michael Kanin",N/A,1967,https://openlibrary.org/works/OL804979W
+The House on the Cliff,Franklin W. Dixon,N/A,1927,https://openlibrary.org/works/OL47927W
+The Maze Runner,James Dashner,N/A,2009,https://openlibrary.org/works/OL6027236W
+Scary stories to tell in the dark,Alvin Schwartz,N/A,1981,https://openlibrary.org/works/OL268379W
+La dame de Monsoreau,Alexandre Dumas,N/A,1840,https://openlibrary.org/works/OL36818W
+Mademoiselle de Maupin,"Théophile Gautier, G. Charpentier (1880), Carolus Duran",N/A,1834,https://openlibrary.org/works/OL10071W
+The first part of the Institutes of the Lawes of England,"Sir Edward Coke, Francis Hargrave, Charles Butler, Sir Matthew Hale, Heneage Finch Nottingham, Thomas de Littleton, Matthew Hale, Butler, Charles, Thomas Littleton, Francis Hargrave",N/A,1628,https://openlibrary.org/works/OL109087W
+The Crime at Black Dudley (Albert Campion #1),Margery Allingham,N/A,1929,https://openlibrary.org/works/OL2004298W
+The Pit,"Frank Norris, Doubleday, Page & Company, J.J. Little (Firm), Donna Campbell",N/A,1903,https://openlibrary.org/works/OL1794919W
+The simple truth,David Baldacci,N/A,1998,https://openlibrary.org/works/OL41252W
+Little Lord Fauntleroy,Frances Hodgson Burnett,N/A,1886,https://openlibrary.org/works/OL69625W
+The Bostonians,"Henry James, Daniel Karlin",N/A,1885,https://openlibrary.org/works/OL276321W
+Judy Moody was in a Mood,Megan McDonald,N/A,2000,https://openlibrary.org/works/OL104358W
+People of the earth,Brian M. Fagan,N/A,1977,https://openlibrary.org/works/OL103280W
+The Sparrow,Mary Doria Russell,N/A,1996,https://openlibrary.org/works/OL2732491W
+Where the Mountain Meets the Moon,"Grace Lin, Janet Song",N/A,2009,https://openlibrary.org/works/OL1913873W
+To All the Boys I've Loved Before,Jenny Han,N/A,2014,https://openlibrary.org/works/OL17203233W
+Walter the baker,Eric Carle,N/A,1972,https://openlibrary.org/works/OL53019W
+Tom Sawyer Abroad,Mark Twain,N/A,1894,https://openlibrary.org/works/OL413674W
+The Grim Grotto,"Lemony Snicket, Brett Helquist, Michael Kupperman",N/A,2004,https://openlibrary.org/works/OL15104140W
+The Vanished Messenger,Edward Phillips Oppenheim,N/A,1914,https://openlibrary.org/works/OL2681038W
+Houghton Mifflin Science California,Houghton Mifflin Company Staff,N/A,2006,https://openlibrary.org/works/OL27468204W
+The Man in the Queue (Inspector Alan Grant #1),Josephine Tey,N/A,1927,https://openlibrary.org/works/OL80940W
+The People of the Abyss,Jack London,N/A,1900,https://openlibrary.org/works/OL144815W
+Snakehead,"Anthony Horowitz, Antony Johnston, Amrit Birdi",N/A,2007,https://openlibrary.org/works/OL14952358W
+The Sun is Also a Star,"Nicola Yoon, KARINE SUHARD - GUIE",N/A,2016,https://openlibrary.org/works/OL18199565W
+Star Wars - The Thrawn Trilogy - The Last Command,Timothy Zahn,N/A,1993,https://openlibrary.org/works/OL83577W
+Under the Banner of Heaven,Jon Krakauer,N/A,2003,https://openlibrary.org/works/OL1974545W
+A Sand County Almanac,Aldo Leopold,N/A,1964,https://openlibrary.org/works/OL3528858W
+The Scarecrow Walks at Midnight,Robert Lawrence Stine,N/A,1994,https://openlibrary.org/works/OL72396W
+The Fourth Apprentice,Erin Hunter,N/A,2009,https://openlibrary.org/works/OL14906957W
+No name,Wilkie Collins,N/A,1862,https://openlibrary.org/works/OL176090W
+Žert,Milan Kundera,N/A,1967,https://openlibrary.org/works/OL10402333W
+The Lessons of History,"Will Durant, Ariel Durant, Parvaneh Shirzad",N/A,1968,https://openlibrary.org/works/OL1073956W
+Dragons of Spring Dawning,"Margaret Weis, Tracy Hickman, Andrew Dabb, Paul Boehmer",N/A,1900,https://openlibrary.org/works/OL73427W
+The birchbark house,Louise Erdrich,N/A,1999,https://openlibrary.org/works/OL479039W
+Soul on ice,"Eldridge Cleaver, E. Cleaver",N/A,1863,https://openlibrary.org/works/OL5849413W
+Scarlett,Alexandra Ripley,N/A,1991,https://openlibrary.org/works/OL3244616W
+Le Cid,Pierre Corneille,N/A,1636,https://openlibrary.org/works/OL15724776W
+The Clash of Civilizations and the Remaking of World Order,Samuel P. Huntington,N/A,1996,https://openlibrary.org/works/OL3289930W
+Sir Nigel,Arthur Conan Doyle,N/A,1906,https://openlibrary.org/works/OL262583W
+River God,Wilbur Smith,N/A,1993,https://openlibrary.org/works/OL8108349W
+The Shadow of the Torturer,Gene Wolfe,N/A,1980,https://openlibrary.org/works/OL14871979W
+King Henry VI. Part 3,William Shakespeare,N/A,1600,https://openlibrary.org/works/OL258713W
+Storm Front,Jim Butcher,N/A,1997,https://openlibrary.org/works/OL5685119W
+Cress,Marissa Meyer,N/A,2014,https://openlibrary.org/works/OL17101027W
+Scarlet,Marissa Meyer,N/A,2013,https://openlibrary.org/works/OL17452055W
+Count Zero,William Gibson,N/A,1986,https://openlibrary.org/works/OL27256W
+Typee,Herman Melville,N/A,1840,https://openlibrary.org/works/OL102748W
+Business Statistics,Ken Black,N/A,1991,https://openlibrary.org/works/OL2838069W
+Me Talk Pretty One Day,David Sedaris,N/A,2000,https://openlibrary.org/works/OL2693077W
+This is going to hurt,Adam Kay,N/A,2017,https://openlibrary.org/works/OL19752167W
+Zahir,Paulo Coelho,N/A,2005,https://openlibrary.org/works/OL796600W
+Why We Can't Wait,"Martin Luther King Jr., J.D. Jackson",N/A,1963,https://openlibrary.org/works/OL1945932W
+Politics among Nations,Hans Morgenthau,N/A,1948,https://openlibrary.org/works/OL1218841W
+Blueberries for Sal,Robert McCloskey,N/A,1948,https://openlibrary.org/works/OL4638387W
+Exodus,Leon Uris,N/A,1958,https://openlibrary.org/works/OL14847881W
+The Rainbow Fish,Marcus Pfister,N/A,1992,https://openlibrary.org/works/OL507216W
+A Mind to Murder,P. D. James,N/A,1963,https://openlibrary.org/works/OL510881W
+The Final Warning,James Patterson,N/A,1998,https://openlibrary.org/works/OL5337410W
+Children of the Mind,Orson Scott Card,N/A,1996,https://openlibrary.org/works/OL49463W
+Dress Your Family in Corduroy and Denim,"David Sedaris, Ehud Tagari",N/A,2004,https://openlibrary.org/works/OL2693096W
+The Orange Fairy Book (Large Print),Andrew Lang,N/A,1906,https://openlibrary.org/works/OL1088838W
+Wifey,Judy Blume,N/A,1978,https://openlibrary.org/works/OL268222W
+Lalla Rookh,"Thomas Moore, T. Moore, Thomas Moore",N/A,1800,https://openlibrary.org/works/OL75267W
+The Hidden Kingdom,Tui Sutherland,N/A,2012,https://openlibrary.org/works/OL16833236W
+The Four Just Men,Edgar Wallace,N/A,1905,https://openlibrary.org/works/OL1517879W
+Sundiata,"Djibril Tamsir Niane, DjiBril Tamsir Niane, D T Niane, D T Niane, G. D. Pickett",N/A,1960,https://openlibrary.org/works/OL4523903W
+The Amateur Cracksman,E. W. Hornung,N/A,1899,https://openlibrary.org/works/OL250352W
+Three guineas,"Virginia Woolf, Mark Hussey, Marta Pessarrodona Artigues, Andrés Bosch",N/A,1938,https://openlibrary.org/works/OL39564W
+The Number of the Beast,Robert A. Heinlein,N/A,1980,https://openlibrary.org/works/OL59705W
+Illusions perdues,Honoré de Balzac,N/A,1837,https://openlibrary.org/works/OL85241W
+Vampire Academy,"Richelle Mead, Richelle Mead",N/A,2007,https://openlibrary.org/works/OL8488892W
+"Looking Backward, 2000-1887",Edward Bellamy,N/A,1888,https://openlibrary.org/works/OL2981506W
+羊をめぐる冒険,村上春樹,N/A,1982,https://openlibrary.org/works/OL2625441W
+Strangers On a Train,"Patricia Highsmith, Michael Nation",N/A,1950,https://openlibrary.org/works/OL59482W
+A Little Life,Hanya Yanagihara,N/A,2015,https://openlibrary.org/works/OL17370186W
+Interpreter of maladies,Jhumpa Lahiri,N/A,1999,https://openlibrary.org/works/OL2001058W
+Daniel Deronda,George Eliot,N/A,1800,https://openlibrary.org/works/OL20933W
+The Dollhouse Murders,Betty Ren Wright,N/A,1983,https://openlibrary.org/works/OL32501W
+"Good morning, midnight",Jean Rhys,N/A,1967,https://openlibrary.org/works/OL1858631W
+Drôle de garçon,Shyam Selvadurai,N/A,1994,https://openlibrary.org/works/OL86020W
+The selfish giant,Oscar Wilde,N/A,1932,https://openlibrary.org/works/OL14877873W
+Beggar's opera,John Gay,N/A,1728,https://openlibrary.org/works/OL1152115W
+True Betrayals,Nora Roberts,N/A,1995,https://openlibrary.org/works/OL111635W
+The affluent society,John Kenneth Galbraith,N/A,1958,https://openlibrary.org/works/OL12581W
+The Wisdom of Insecurity,Alan Watts,N/A,1951,https://openlibrary.org/works/OL266158W
+Thomas and Friends,Reverend W. Awdry,N/A,2003,https://openlibrary.org/works/OL8038409W
+The Diary of a Nobody,"George Grossmith, Weedon Grossmith",N/A,1921,https://openlibrary.org/works/OL20259087W
+Lincoln in the Bardo,"George Saunders, Javier Calvo Perales, Yannick Garcia Porres",N/A,2017,https://openlibrary.org/works/OL17635834W
+Batman,"Alan Moore, Brian Bolland, Alan Moore, John Higgins, Richard Starkings",N/A,1988,https://openlibrary.org/works/OL2897789W
+The Bachman Books (Long Walk / Rage / Roadwork / Running Man),Stephen King,N/A,1985,https://openlibrary.org/works/OL81591W
+Φίληβος,Πλάτων,N/A,1779,https://openlibrary.org/works/OL51806W
+The Primer (The Book of Common Prayer),Church of England,N/A,1510,https://openlibrary.org/works/OL769112W
+Notizbuch,Coole Notizbucher,N/A,2019,https://openlibrary.org/works/OL21886165W
+Big Little Lies,Liane Moriarty,N/A,2014,https://openlibrary.org/works/OL17116911W
+Princess Academy,Shannon Hale,N/A,2005,https://openlibrary.org/works/OL5738591W
+Victory,Joseph Conrad,N/A,1915,https://openlibrary.org/works/OL38763W
+Shoe Dog,Phil Knight,N/A,2016,https://openlibrary.org/works/OL17825802W
+Diaries,Joseph Goebbels,N/A,1948,https://openlibrary.org/works/OL625220W
+The Insidious Dr. Fu Manchu,Sax Rohmer,N/A,1913,https://openlibrary.org/works/OL2288684W
+Forest of Secrets,Erin Hunter,N/A,2003,https://openlibrary.org/works/OL5714292W
+Beauty's Punishment,Anne Rice,N/A,1984,https://openlibrary.org/works/OL77793W
+Quarto de Despejo,Carolina Maria de Jesus,N/A,1960,https://openlibrary.org/works/OL1810404W
+The Woman in the Window: A Novel,A. J. Finn,N/A,2017,https://openlibrary.org/works/OL18147682W
+The Magnificent Ambersons,Booth Tarkington,N/A,1917,https://openlibrary.org/works/OL54896W
+Liar's Poker,Michael Lewis,N/A,1989,https://openlibrary.org/works/OL7944812W
+The Innovator's Dilemma,"Clayton M. Christensen, L J Ganser, Don Leslie",N/A,1997,https://openlibrary.org/works/OL1999873W
+What Maisie Knew,Henry James,N/A,1897,https://openlibrary.org/works/OL276469W
+Getting Things Done,"David Allen, David Allen, David Allen",N/A,2001,https://openlibrary.org/works/OL271504W
+Simon vs. the Homo Sapiens Agenda,"Becky Albertalli, Victoria Simó Perales",N/A,2015,https://openlibrary.org/works/OL17357353W
+The Stone Diaries,Carol Shields,N/A,1993,https://openlibrary.org/works/OL18343W
+Killers of the Flower Moon,"David Grann, Luis Murillo Fort",N/A,2017,https://openlibrary.org/works/OL17778665W
+The Heir (The Selection #4),Kiera Cass,N/A,2015,https://openlibrary.org/works/OL17104741W
+The Titan,Theodore Dreiser,N/A,1914,https://openlibrary.org/works/OL100238W
+Labyrinths,Jorge Luis Borges,N/A,1962,https://openlibrary.org/works/OL110959W
+The Secret,Rhonda Byrne,N/A,2000,https://openlibrary.org/works/OL15839737W
+Ruby the Red Fairy,Daisy Meadows,N/A,2003,https://openlibrary.org/works/OL5886978W
+"The nigger of the ""Narcissus""",Joseph Conrad,N/A,1897,https://openlibrary.org/works/OL38815W
+Parable of the sower,Octavia E. Butler,N/A,1993,https://openlibrary.org/works/OL35623W
+Crossing the Chasm,Geoffrey A. Moore,N/A,1991,https://openlibrary.org/works/OL30695W
+The Book,Alan Watts,N/A,1966,https://openlibrary.org/works/OL1877201W
+All-of-a-Kind Family,"Sydney Taylor, Helen John",N/A,1951,https://openlibrary.org/works/OL6329150W
+The Freedom of Life,Annie Payson Call,N/A,1905,https://openlibrary.org/works/OL7711731W
+Banner in the Sky,James Ramsey Ullman,N/A,1954,https://openlibrary.org/works/OL1519625W
+Jean-Christophe,Romain Rolland,N/A,1900,https://openlibrary.org/works/OL68141W
+Blood Canticle,Anne Rice,N/A,1998,https://openlibrary.org/works/OL77820W
+Feeling good,David D. Burns,N/A,1980,https://openlibrary.org/works/OL4310025W
+"Sybil, or, The Two Nations",Benjamin Disraeli,N/A,1830,https://openlibrary.org/works/OL1104332W
+Yertle the turtle,Dr. Seuss,N/A,1958,https://openlibrary.org/works/OL261235W
+"The general theory of employment, interest and money",John Maynard Keynes,N/A,1935,https://openlibrary.org/works/OL35951W
+The Secret at Shadow Ranch,Mildred Augustine Wirt Benson,N/A,1931,https://openlibrary.org/works/OL39394W
+Magician,Raymond E. Feist,N/A,1982,https://openlibrary.org/works/OL554687W
+Misal diario y vesperal,Catholic Church,N/A,1806,https://openlibrary.org/works/OL15161992W
+The Gene,"Siddhartha Mukherjee, Dennis Boutsikaris",N/A,2016,https://openlibrary.org/works/OL17762235W
+Jane's All the Worlds Aircraft,Fred T. Jane,N/A,1933,https://openlibrary.org/works/OL3811469W
+The Woman Destroyed,Simone de Beauvoir,N/A,1967,https://openlibrary.org/works/OL767903W
+The Terminal Man,Michael Crichton,N/A,1972,https://openlibrary.org/works/OL46875W
+Bedtime for Frances,"Russell Hoban, Garth Williams, Lillian Hoban",N/A,1960,https://openlibrary.org/works/OL74253W
+A Visit from the Goon Squad,Jennifer Egan,N/A,2010,https://openlibrary.org/works/OL15026613W
+The Fifth Elephant,Terry Pratchett,N/A,1999,https://openlibrary.org/works/OL453684W
+The Disappearing Spoon,Sam Kean,N/A,2010,https://openlibrary.org/works/OL15441038W
+Wool,Hugh Howey,N/A,2011,https://openlibrary.org/works/OL16800608W
+A Suitable Boy,Vikram Seth,N/A,1993,https://openlibrary.org/works/OL11930W
+A Good Girl's Guide to Murder,Holly Jackson,N/A,2019,https://openlibrary.org/works/OL20646061W
+Gender Trouble,Judith Butler,N/A,1989,https://openlibrary.org/works/OL893584W
+Wolf-Speaker (The Immortals #2),Tamora Pierce,N/A,1994,https://openlibrary.org/works/OL29263W
+Going to Meet the Man,James Baldwin,N/A,1965,https://openlibrary.org/works/OL228703W
+Rich dad's guide to investing,"Robert T. Kiyosaki, Sharon L. Lechter",N/A,2000,https://openlibrary.org/works/OL2010894W
+The Duke and I,Julia Quinn,N/A,2000,https://openlibrary.org/works/OL554620W
+Abnormal Psychology,"Irwin G. Sarason, Barbara R. Sarason, Irwin Gerald Sarason",N/A,1969,https://openlibrary.org/works/OL1802485W
+American Indian Stories,"Zitkála-Šá, Desmond gahan",N/A,1921,https://openlibrary.org/works/OL5478557W
+A Survey of London,"John Stow, C. L. Kingsford, Kingsford, Charles Lethbridge, John Mottley, John Strype",N/A,1598,https://openlibrary.org/works/OL1096157W
+Hyperion,Dan Simmons,N/A,1989,https://openlibrary.org/works/OL1963268W
+Jane's Fighting Ships,Fred T. Jane,N/A,1898,https://openlibrary.org/works/OL1861097W
+Year of Wonders,Geraldine Brooks,N/A,2001,https://openlibrary.org/works/OL2011278W
+McTeague,"Frank Norris, F Norris, FrankNorris",N/A,1899,https://openlibrary.org/works/OL1794911W
+Human physiology,Stuart Ira Fox,N/A,1984,https://openlibrary.org/works/OL2730163W
+Justice,Michael J. Sandel,N/A,2007,https://openlibrary.org/works/OL1810923W
+Test of the Twins,"Margaret Weis, Tracy Hickman",N/A,1986,https://openlibrary.org/works/OL73424W
+Words of Radiance,Brandon Sanderson,N/A,2012,https://openlibrary.org/works/OL16813053W
+Telling Lies,Paul Ekman,N/A,1985,https://openlibrary.org/works/OL3858313W
+The Diary of Anne Frank,"Frances Goodrich, Albert Hackett, Anne Frank",N/A,1956,https://openlibrary.org/works/OL5259772W
+Lies My Teacher Told Me,"James W. Loewen, Rebecca Stefoff",N/A,1994,https://openlibrary.org/works/OL106813W
+The Seven Husbands of Evelyn Hugo,Taylor Jenkins Reid,N/A,2017,https://openlibrary.org/works/OL18203673W
+Point Counter Point,Aldous Huxley,N/A,1642,https://openlibrary.org/works/OL64465W
+"The calculus, with analytic geometry","Louis Leithold, Leithold",N/A,1967,https://openlibrary.org/works/OL2937317W
+Men of Iron,Howard Pyle,N/A,1891,https://openlibrary.org/works/OL25601428W
+Fool Moon,"Jim Butcher, Mark Powers, Chase Conley, Tyler Walpole, James Marsters",N/A,2001,https://openlibrary.org/works/OL5961788W
+Human Biology,Sylvia S. Mader,N/A,1988,https://openlibrary.org/works/OL2657845W
+An Occurrence at Owl Creek Bridge,Ambrose Bierce,N/A,1980,https://openlibrary.org/works/OL14863196W
+Systems Analysis and Design,"Alan Dennis, Barbara Haley Wixom, David Tegarden, Roberta M. Roth",N/A,2000,https://openlibrary.org/works/OL5973035W
+The Thing Around Your Neck,Chimamanda Ngozi Adichie,N/A,2009,https://openlibrary.org/works/OL5731541W
+Intermediate algebra,"Margaret L. Lial, E. John Hornsby, Terry McGinnis",N/A,1972,https://openlibrary.org/works/OL17104W
+A Moveable Feast,Ernest Hemingway,N/A,1964,https://openlibrary.org/works/OL63064W
+Altered Carbon. Vol. 1,Richard K. Morgan,N/A,2002,https://openlibrary.org/works/OL29914687W
+The Return of the Prodigal Son,Henri J. M. Nouwen,N/A,1992,https://openlibrary.org/works/OL1913415W
+Magic Fishbone,Charles Dickens,N/A,1911,https://openlibrary.org/works/OL14870135W
+Let's Get Invisible!,Robert Lawrence Stine,N/A,1993,https://openlibrary.org/works/OL72416W
+While my pretty one sleeps,Mary Higgins Clark,N/A,1989,https://openlibrary.org/works/OL13069W
+Treasure Island,"Robert Louis Stevenson, Jim Seward",N/A,1881,https://openlibrary.org/works/OL29469980W
+Seven keys to Baldpate,Earl Derr Biggers,N/A,1913,https://openlibrary.org/works/OL6438826W
+Voice in the Wind,"Francine Rivers, Francine Rivers",N/A,1993,https://openlibrary.org/works/OL13015028W
+Tarikhe auliya egujrat,Tobias Smollett,N/A,1771,https://openlibrary.org/works/OL814711W
+Welcome to the Monkey House,Kurt Vonnegut,N/A,1950,https://openlibrary.org/works/OL98480W
+The Screaming Staircase,Jonathan Stroud,N/A,2013,https://openlibrary.org/works/OL17922617W
+The Day the Crayons Quit,Drew Daywalt,N/A,2013,https://openlibrary.org/works/OL17104369W
+What the Buddha taught,Walpola Rahula,N/A,1959,https://openlibrary.org/works/OL2314435W
+Midnight for Charlie Bone,"Jenny Nimmo, Simon Russell Beale",N/A,2002,https://openlibrary.org/works/OL451778W
+The Purpose-Driven Life,Rick Warren,N/A,1997,https://openlibrary.org/works/OL16335306W
+The Wild Robot,Peter Brown,N/A,2016,https://openlibrary.org/works/OL17365087W
+Les contes drôlatiques,Honoré de Balzac,N/A,1855,https://openlibrary.org/works/OL85056W
+The Road Ahead,"Bill Gates, Nathan Myhrvold, Peter Rinearson",N/A,1995,https://openlibrary.org/works/OL53676W
+The Foot Book,Dr. Seuss,N/A,1968,https://openlibrary.org/works/OL1898304W
+The 36-hour day,"Nancy L. Mace, Peter V. Rabins, Nancy L Mace",N/A,1981,https://openlibrary.org/works/OL1976081W
+The secret of childhood,Maria Montessori,N/A,1936,https://openlibrary.org/works/OL1542660W
+How to read a book,"Mortimer J. Adler, Charles van Doren, Charles Lincoln Van Doren",N/A,1940,https://openlibrary.org/works/OL487444W
+The Happy Prince and other stories,Oscar Wilde,N/A,1889,https://openlibrary.org/works/OL14877854W
+The Tower of Nero,Rick Riordan,N/A,2020,https://openlibrary.org/works/OL20780974W
+Life Lessons,Max Lucado,N/A,1996,https://openlibrary.org/works/OL57157W
+Amari and the Night Brothers,B. B. Alston,N/A,2021,https://openlibrary.org/works/OL21705742W
+L'affaire Lerouge,Émile Gaboriau,N/A,1800,https://openlibrary.org/works/OL1546094W
+"My sister, the serial killer","Oyinkan Braithwaite, Iulia Gorzo, Elena Malanga",N/A,2018,https://openlibrary.org/works/OL19761909W
+A Grimm Warning,Chris Colfer,N/A,2014,https://openlibrary.org/works/OL17366446W
+Pagan Papers,Kenneth Grahame,N/A,1894,https://openlibrary.org/works/OL69600W
+Tender Buttons,Gertrude Stein,N/A,1914,https://openlibrary.org/works/OL35395W
+The power of one,Bryce Courtenay,N/A,1989,https://openlibrary.org/works/OL883475W
+Unbehagen in der Kultur,Sigmund Freud,N/A,1930,https://openlibrary.org/works/OL1069203W
+Chicken Soup for the Soul,"Jack Canfield, Mark Victor Hansen, Amy Newmark",N/A,1993,https://openlibrary.org/works/OL3180520W
+The Princess Diaries,Meg Cabot,N/A,2000,https://openlibrary.org/works/OL492872W
+Me and Earl and the Dying Girl,Jesse Andrews,N/A,2012,https://openlibrary.org/works/OL16190785W
+Mating in Captivity,Esther Perel,N/A,2006,https://openlibrary.org/works/OL275862W
+The Voice of the Night,Dean Koontz,N/A,1980,https://openlibrary.org/works/OL263277W
+The least you should know about English,"Paige Wilson, Paige L. Wilson, Teresa Ferster Glazier",N/A,1994,https://openlibrary.org/works/OL6033471W
+Patterns of fashion,Janet Arnold,N/A,1964,https://openlibrary.org/works/OL1677525W
+The Baby-Sitters Club,Ann M. Martin,N/A,1989,https://openlibrary.org/works/OL8117434W
+The Giving Tree,Shel Silverstein,N/A,1964,https://openlibrary.org/works/OL3368288W
+The Flame and the Flower,Kathleen E. Woodiwiss,N/A,1972,https://openlibrary.org/works/OL59383W
+Heartless,Marissa Meyer,N/A,2000,https://openlibrary.org/works/OL17886378W
+The Cave of Time,Edward Packard,N/A,1979,https://openlibrary.org/works/OL30117W
+The Painted Bird,Jerzy N. Kosinski,N/A,1965,https://openlibrary.org/works/OL10695417W
+A princess remembers,"Gayatri Devi, Santha Rama Rau",N/A,1976,https://openlibrary.org/works/OL3217399W
+The Chessmen of Mars,Edgar Rice Burroughs,N/A,1922,https://openlibrary.org/works/OL1418244W
+Pedagogia do oprimido,Paulo Freire,N/A,1967,https://openlibrary.org/works/OL1870556W
+The Two Noble Kinsmen,"John Fletcher, William Shakespeare",N/A,1634,https://openlibrary.org/works/OL258996W
+Phänomenologie des Geistes,Georg Wilhelm Friedrich Hegel,N/A,1907,https://openlibrary.org/works/OL678515W
+The butterfly lion,"Michael Morpurgo, Christian Birmingham, Michael Mopurgo",N/A,1996,https://openlibrary.org/works/OL42731W
+City of Fallen Angels,Cassandra Clare,N/A,2011,https://openlibrary.org/works/OL15701782W
+The Art of Seduction,"Robert Greene, Joost Elffers",N/A,2001,https://openlibrary.org/works/OL1968364W
+Bravo Two Zero,Andy McNab,N/A,1991,https://openlibrary.org/works/OL1978001W
+Art and illusion,E. H. Gombrich,N/A,1960,https://openlibrary.org/works/OL686192W
+The Noonday Demon,Andrew Solomon,N/A,2001,https://openlibrary.org/works/OL3457531W
+Amelia Bedelia and the Shower Surprise,Peggy Parish,N/A,1966,https://openlibrary.org/works/OL1932895W
+Der 18. Brumaire des Louis Bonaparte,"Karl Marx, Daniel De Leon, Karl Marx, Sankar Srinivasan, Hauke Brunkhorst",N/A,1869,https://openlibrary.org/works/OL628458W
+Desert solitaire,Edward Abbey,N/A,1968,https://openlibrary.org/works/OL2929632W
+"The Lottery, or The Adventures of James Harris",Shirley Jackson,N/A,1949,https://openlibrary.org/works/OL3171083W
+"Goodbye, Columbus and five short stories",Philip Roth,N/A,1959,https://openlibrary.org/works/OL74657W
+Lord of Light,Roger Zelazny,N/A,1967,https://openlibrary.org/works/OL13992W
+The Man with the Golden Gun,Ian Fleming,N/A,1822,https://openlibrary.org/works/OL85741W
+At the Mountains of Madness,"H.P. Lovecraft, Enrique Breccia",N/A,1968,https://openlibrary.org/works/OL152268W
+A Court of Wings and Ruin,Sarah J. Maas,N/A,2017,https://openlibrary.org/works/OL17823218W
+The Mind Map Book,"Tony Buzan, Barry Buzan",N/A,1993,https://openlibrary.org/works/OL1952692W
+The Bazaar of Bad Dreams,Stephen King,N/A,2015,https://openlibrary.org/works/OL17823750W
+Damals war es Friedrich,Hans Peter Richter,N/A,1963,https://openlibrary.org/works/OL5268553W
+The Velveteen Rabbit,Margery Williams Bianco,N/A,1958,https://openlibrary.org/works/OL274440W
+Industrial Society and Its Future,Theodore Kaczynski,N/A,1995,https://openlibrary.org/works/OL9003449W
+A Random Walk Down Wall Street,Burton Gordon Malkiel,N/A,1973,https://openlibrary.org/works/OL2000283W
+Elogio de la madrasta,"Mario Vargas Llosa, Helen Lane",N/A,1988,https://openlibrary.org/works/OL857575W
+Flappers and Philosophers,F. Scott Fitzgerald,N/A,1920,https://openlibrary.org/works/OL468404W
+Till We Have Faces,C.S. Lewis,N/A,1956,https://openlibrary.org/works/OL71162W
+The wars,Timothy Findley,N/A,1977,https://openlibrary.org/works/OL102445W
+The hollow boy,Jonathan Stroud,N/A,2015,https://openlibrary.org/works/OL19671508W
+The Cruel Prince,Holly Black,N/A,2018,https://openlibrary.org/works/OL17850410W
+Vita di Benvenuto Cellini,Benvenuto Cellini,N/A,1728,https://openlibrary.org/works/OL1091251W
+When Calls the Heart (Canadian West #1),"Janette Oke, Jr Michael Landon",N/A,1983,https://openlibrary.org/works/OL97190W
+On the sublime,Longinus,N/A,1612,https://openlibrary.org/works/OL2101248W
+After the fact,James West Davidson,N/A,1981,https://openlibrary.org/works/OL57276W
+Moonrise,Erin Hunter,N/A,2005,https://openlibrary.org/works/OL24333134W
+Traditions & encounters,"Jerry H. Bentley, Herbert Ziegler, Herbert F. Ziegler, Jerry Bentley, Heather Streets, Jerry H Bentley, Jerry H. Bentley, Herbert F. Ziegler",N/A,1999,https://openlibrary.org/works/OL4289172W
+Flint,Louis L'Amour,N/A,1960,https://openlibrary.org/works/OL51076W
+The Line of Beauty,Alan Hollinghurst,N/A,2004,https://openlibrary.org/works/OL1993508W
+The Road to Reality,Roger Penrose,N/A,2004,https://openlibrary.org/works/OL3474173W
+Nightfall,Isaac Asimov,N/A,1969,https://openlibrary.org/works/OL46374W
+The Tao of Pooh,"Benjamin Hoff, Ernest H. Shepard, A. A. Milne",N/A,1982,https://openlibrary.org/works/OL3913006W
+Wayside School is Falling Down (Wayside School #2),Louis Sachar,N/A,1989,https://openlibrary.org/works/OL116265W
+Apollonius Rhodius,Apollonius Rhodius,N/A,1550,https://openlibrary.org/works/OL2382360W
+The Gathering Storm,"Robert Jordan, Brandon Sanderson, Robert Jordan",N/A,2009,https://openlibrary.org/works/OL1946681W
+The big short,Michael Lewis,N/A,2010,https://openlibrary.org/works/OL15118378W
+Baudolino,Umberto Eco,N/A,2000,https://openlibrary.org/works/OL8995682W
+Elon Musk,"Ashlee Vance, Francisco López Martín",N/A,2013,https://openlibrary.org/works/OL17184556W
+The House of God,Samuel Shem,N/A,1978,https://openlibrary.org/works/OL1884679W
+"Chitty-Chitty-Bang-Bang, the magical car",Ian Fleming,N/A,1964,https://openlibrary.org/works/OL85731W
+American Pastoral,Philip Roth,N/A,1997,https://openlibrary.org/works/OL74666W
+Psycho,Robert Bloch,N/A,1959,https://openlibrary.org/works/OL6395593W
+Il sistema periodico,Primo Levi,N/A,1975,https://openlibrary.org/works/OL860022W
+The Wept of Wish-ton-wish: A Tale,James Fenimore Cooper,N/A,1829,https://openlibrary.org/works/OL77977W
+The Great Transformation,Karl Polanyi,N/A,1944,https://openlibrary.org/works/OL3617884W
+Mathematics for elementary teachers,"Gary L. Musser, William F. Burger, Blake E. Peterson",N/A,1988,https://openlibrary.org/works/OL458304W
+Phèdre,Jean Racine,N/A,1805,https://openlibrary.org/works/OL741417W
+The Infinite Sea,Richard Yancey,N/A,2014,https://openlibrary.org/works/OL17305107W
+Sojourn,R. A. Salvatore,N/A,1991,https://openlibrary.org/works/OL516683W
+Hop on Pop,Dr. Seuss,N/A,1963,https://openlibrary.org/works/OL261164W
+Economics,McGraw-Hill,N/A,1998,https://openlibrary.org/works/OL14996318W
+Not Without My Daughter,"Betty Mahmoody, William Hoffer",N/A,1987,https://openlibrary.org/works/OL4064350W
+A Chair for My Mother,"Vera B. Williams, Susan Rybin",N/A,1982,https://openlibrary.org/works/OL3243597W
+The storied life of A. J. Fikry,"Gabrielle Zevin, Scott Brick",N/A,2014,https://openlibrary.org/works/OL16819586W
+The history of witchcraft and demonology,Montague Summers,N/A,1926,https://openlibrary.org/works/OL114032W
+The Prisoner of Zenda,"Anthony Hope, Gary Hoppenstand, Diane Mowat, Alan Marks, Francesc Ràfols, Andrew Pugsley, Summer M. Hogan, Summer Hogan, Smidgen Press, Charles Dana Gibson, Daniel Lanza Barba, Javier Fornell Fernandez, Stephen Colbourn, Katy Jackson, James Wilby, Robinson, M.",N/A,1800,https://openlibrary.org/works/OL245401W
+The Complete Adventures of Charlie and Willy Wonka (Charlie and the Chocolate Factory / Charlie and the Great Glass Elevator),Roald Dahl,N/A,1978,https://openlibrary.org/works/OL45843W
+Empire of Storms,Sarah J. Maas,N/A,2016,https://openlibrary.org/works/OL17625829W
+The incredulity of Father Brown,"Gilbert Keith Chesterton, Andronum (cover illustrator)",N/A,1920,https://openlibrary.org/works/OL76460W
+The Black Robe,"Wilkie Collins, Wilkie Collins",N/A,1881,https://openlibrary.org/works/OL176068W
+Fooled by randomness,Nassim Nicholas Taleb,N/A,2001,https://openlibrary.org/works/OL3295029W
+The Best Christmas Pageant Ever,Barbara Robinson,N/A,1972,https://openlibrary.org/works/OL3534104W
+Les lettres de mon moulin,"Alphonse Daudet, Editions Editions AOJB, Didier Hallépée, Editions du Rey, José Roy, Fraipont",N/A,1869,https://openlibrary.org/works/OL942495W
+A history of graphic design,"Philip B. Meggs, Alston W. Purvis, Alston Purvi",N/A,1983,https://openlibrary.org/works/OL2722401W
+Tarzan the Terrible (#8),"Edgar Rice Burroughs, Red Maple, J. Allen St. John",N/A,1921,https://openlibrary.org/works/OL1418108W
+The end,"Lemony Snicket, Brett Helquist, Michael Kupperman",N/A,2006,https://openlibrary.org/works/OL24850567W
+Daisy Jones & The Six,Taylor Jenkins Reid,N/A,2019,https://openlibrary.org/works/OL19922194W
+"Revelations of divine love, recorded by Julian, anchoress at Norwich, A.D. 1373","Julian of Norwich, Warrack, Grace Harriet, 1855-1932, Julian, Frances Beer, Edmund Colledge, James Walsh, Jean Leclercq, John Skinner",N/A,1901,https://openlibrary.org/works/OL742115W
+Daphnis and Chloe,"Longus, Otto Schönberger",N/A,1717,https://openlibrary.org/works/OL2156811W
+Bucolica,Publius Vergilius Maro,N/A,1806,https://openlibrary.org/works/OL16280229W
+Novels (Emma / Mansfield Park / Northanger Abbey / Persuasion / Pride and Prejudice / Sense and Sensibility),Jane Austen,N/A,1818,https://openlibrary.org/works/OL66512W
+The Bourne Identity,Robert Ludlum,N/A,1980,https://openlibrary.org/works/OL2664916W
+The Mist,Stephen King,N/A,1925,https://openlibrary.org/works/OL149144W
+When the Body Says No,Gabor Maté,N/A,2003,https://openlibrary.org/works/OL8299076W
+The Saint' everlasting rest,"Richard Baxter, Isaac Crewdson, John Wesley",N/A,1650,https://openlibrary.org/works/OL3873582W
+Der Zahlenteufel,Hans Magnus Enzensberger,N/A,1997,https://openlibrary.org/works/OL973176W
+The Last Hero,Terry Pratchett,N/A,2001,https://openlibrary.org/works/OL453768W
+The Doors of Perception / Heaven and Hell,Aldous Huxley,N/A,1956,https://openlibrary.org/works/OL64442W
+Strong Poison,Dorothy L. Sayers,N/A,1930,https://openlibrary.org/works/OL2234905W
+Stars Through the Mist,Betty Neels,N/A,1957,https://openlibrary.org/works/OL3457886W
+The Courage to Heal,"Ellen Bass, Laura Davis",N/A,1988,https://openlibrary.org/works/OL3238487W
+The Zombie Survival Guide,Max Brooks,N/A,2003,https://openlibrary.org/works/OL5969056W
+The Girl Who Drank the Moon,"Kelly Regan Barnhill, Isabel Murillo",N/A,2016,https://openlibrary.org/works/OL17627845W
+Thud!,Terry Pratchett,N/A,2005,https://openlibrary.org/works/OL453852W
+Kenilworth,Sir Walter Scott,N/A,1800,https://openlibrary.org/works/OL863804W
+"Ageless body, timeless mind",Deepak Chopra,N/A,1993,https://openlibrary.org/works/OL548765W
+Outliers,Malcolm Gladwell,N/A,2008,https://openlibrary.org/works/OL5749847W
+Clockwork Angel,Cassandra Clare,N/A,2010,https://openlibrary.org/works/OL15370343W
+The River,Gary Paulsen,N/A,1991,https://openlibrary.org/works/OL14850218W
+The Second Common Reader,Virginia Woolf,N/A,1925,https://openlibrary.org/works/OL39589W
+A House-Boat on the Styx,"John Kendrick Bangs, Peter Newell, Ohn Kendrick Bangs",N/A,1895,https://openlibrary.org/works/OL1868689W
+The Guns of August,Barbara Tuchman,N/A,1962,https://openlibrary.org/works/OL3378527W
+Pippi Langstrump i Söderhavet,Astrid Lindgren,N/A,1957,https://openlibrary.org/works/OL14872949W
+"Erinnerungen, Träume, Gedanken",Carl Gustav Jung,N/A,1961,https://openlibrary.org/works/OL95094W
+The Assassin’s Blade,Sarah J. Maas,N/A,2014,https://openlibrary.org/works/OL17546674W
+The Psychology of Money,Morgan Housel,N/A,2020,https://openlibrary.org/works/OL21640039W
+Mathematics for the million,Lancelot Thomas Hogben,N/A,1936,https://openlibrary.org/works/OL95059W
+Band of Brothers,Stephen E. Ambrose,N/A,1992,https://openlibrary.org/works/OL478550W
+Factfulness,"Hans Rosling, Ola Rosling, Anna Rosling Rönnlund",N/A,2018,https://openlibrary.org/works/OL17877260W
+The Dragonbone Chair,Tad Williams,N/A,1988,https://openlibrary.org/works/OL2250813W
+Curious George,"H. A. Rey, Margret Rey",N/A,1941,https://openlibrary.org/works/OL2023849W
+The Atlantic,"Editors of The Atlantic, Writers of The Atlantic",N/A,1857,https://openlibrary.org/works/OL17773293W
+Harry by the Sea,"Gene Zion, Margaret Bloy Graham",N/A,1965,https://openlibrary.org/works/OL1973377W
+Meditationes de prima philosophia,René Descartes,N/A,1642,https://openlibrary.org/works/OL1151517W
+The C++ programming language,Bjarne Stroustrup,N/A,1986,https://openlibrary.org/works/OL53184W
+Hollywood Wives,Jackie Collins,N/A,1983,https://openlibrary.org/works/OL33814W
+Dr. ​Mengele boncolóorvosa voltam az auschwitzi krematóriumban,Miklós Nyiszli,N/A,1960,https://openlibrary.org/works/OL3931534W
+Manufacturing consent,"Edward S. Herman, Noam Chomsky, Edward S. Herman, John Pruden",N/A,1988,https://openlibrary.org/works/OL31013W
+Breakfast of Champions,Kurt Vonnegut,N/A,1973,https://openlibrary.org/works/OL98488W
+The Rivals,Richard Brinsley Sheridan,N/A,1775,https://openlibrary.org/works/OL1062545W
+On Tyranny,"Timothy Snyder, Núria Parés Sellarés",N/A,2017,https://openlibrary.org/works/OL17710110W
+Treasury Bulletin,"United States Dept of the Treasury, United States Dept of the Treasury Bu, United States Dept of the Treasury Fi",N/A,2018,https://openlibrary.org/works/OL28537439W
+The Naked and the Dead,Norman Mailer,N/A,1948,https://openlibrary.org/works/OL1822241W
+The wheels of chance,H. G. Wells,N/A,1896,https://openlibrary.org/works/OL52247W
+Story About Ping,Marjorie Flack,N/A,1933,https://openlibrary.org/works/OL2588330W
+Allan Quatermain,H. Rider Haggard,N/A,1887,https://openlibrary.org/works/OL17465W
+The science of nutrition,"Janice Thompson, Janice Thompson, Melinda Manore, Linda Vaughan, Linda A. Vaughan, Kathy Gottschall-Pass, Debbie MacLellan, Janice J. Thompson",N/A,2007,https://openlibrary.org/works/OL15596858W
+Animal Farm / Nineteen Eighty-Four,George Orwell,N/A,1978,https://openlibrary.org/works/OL1167981W
+La princesse de Clèves,Madame de La Fayette,N/A,1678,https://openlibrary.org/works/OL1244915W
+Brave New World and Brave New World Revisited,Aldous Huxley,N/A,1942,https://openlibrary.org/works/OL64440W
+The Crossover,Kwame Alexander,N/A,2014,https://openlibrary.org/works/OL17081974W
+The time keeper,Mitch Albom,N/A,2011,https://openlibrary.org/works/OL16646239W
+Storm of the Century,Stephen King,N/A,1999,https://openlibrary.org/works/OL81592W
+The great impersonation,Edward Phillips Oppenheim,N/A,1920,https://openlibrary.org/works/OL241517W
+The Tarot Revealed,Eden Gray,N/A,1960,https://openlibrary.org/works/OL4848574W
+Summer sisters,Judy Blume,N/A,1998,https://openlibrary.org/works/OL1838361W
+King Henry VI. Part 1,William Shakespeare,N/A,1735,https://openlibrary.org/works/OL258712W
+Quicksilver,Neal Stephenson,N/A,2003,https://openlibrary.org/works/OL38495W
+"Tales from Earthsea (The Earthsea Cycle, Book 5)",Ursula K. Le Guin,N/A,2001,https://openlibrary.org/works/OL59812W
+Romeo & Juliet,William Shakespeare,N/A,1939,https://openlibrary.org/works/OL26030510W
+The Mystery of Cloomber,Arthur Conan Doyle,N/A,1895,https://openlibrary.org/works/OL262473W
+Robot Dreams,Isaac Asimov,N/A,1986,https://openlibrary.org/works/OL46190W
+Poor things,Alasdair Gray,N/A,1992,https://openlibrary.org/works/OL2466636W
+Out of the Dust,Karen Hesse,N/A,1997,https://openlibrary.org/works/OL1847168W
+A Court of Frost and Starlight,Sarah J. Maas,N/A,2014,https://openlibrary.org/works/OL19655889W
+In the Woods,Tana French,N/A,2007,https://openlibrary.org/works/OL7989979W
+Star Wars Episode III - Revenge of the Sith,Matthew Woodring Stover,N/A,2005,https://openlibrary.org/works/OL2727030W
+The Poet X,Elizabeth Acevedo,N/A,2018,https://openlibrary.org/works/OL19734273W
+The Age of Reason,Thomas Paine,N/A,1794,https://openlibrary.org/works/OL60357W
+Lonesome Dove,Larry McMurtry,N/A,1985,https://openlibrary.org/works/OL134601W
+If I Ran the Zoo,Dr. Seuss,N/A,1950,https://openlibrary.org/works/OL261177W
+Grave Peril,"Jim Butcher, James Marsters",N/A,2001,https://openlibrary.org/works/OL5961784W
+The Mousetrap,Agatha Christie,N/A,1954,https://openlibrary.org/works/OL472819W
+The mitten,Jan Brett,N/A,1989,https://openlibrary.org/works/OL13933W
+The Magic in the Weaving,Tamora Pierce,N/A,1997,https://openlibrary.org/works/OL29252W
+The Romance of Lust,"""Charlie Roberts""",N/A,1968,https://openlibrary.org/works/OL25621436W
+Dawn,Erin Hunter,N/A,2005,https://openlibrary.org/works/OL5714287W
+The First World War,John Keegan,N/A,1998,https://openlibrary.org/works/OL816421W
+Beast Quest,Adam Blade,N/A,2007,https://openlibrary.org/works/OL8122311W
+The story girl,Lucy Maud Montgomery,N/A,1911,https://openlibrary.org/works/OL77786W
+The Seven Deaths of Evelyn Hardcastle,"Stuart Turton, James Cameron Stewart, Fabrice Pointeau",N/A,2018,https://openlibrary.org/works/OL17929039W
+Freaky Friday (Cascades),Mary Rodgers,N/A,1972,https://openlibrary.org/works/OL529408W
+Birds,Aristophanes,N/A,1824,https://openlibrary.org/works/OL20245W
+Le répertoire de la cuisine,Louis Saulnier,N/A,1914,https://openlibrary.org/works/OL189773W
+The Maidens,"Alex Michaelides, Laura Martín de Dios;, Laura Manero Jiménez",N/A,2021,https://openlibrary.org/works/OL34962371W
+Next,Michael Crichton,N/A,2006,https://openlibrary.org/works/OL46904W
+SRA Open Court reading.,"Marilyn Jager Adams, WrightGroup/McGraw-Hill, Jager, Carl Bereiter, Michael Pressley, Marsha, Ph.D. Roit, Anne McKeough, Jan Hirshberg, Marlene Scardamalia, Joe, Ph.D. Campione, Iva Carruthers, Gerald H., Jr. Treadway, Noeila Esparza",N/A,2000,https://openlibrary.org/works/OL15164122W
+Death in the Stocks,Georgette Heyer,N/A,1935,https://openlibrary.org/works/OL4092670W
+The ascent of money,Niall Ferguson,N/A,2008,https://openlibrary.org/works/OL792952W
+Crime and Punishment,Фёдор Михайлович Достоевский,N/A,2009,https://openlibrary.org/works/OL24574391W
+Physico-theology,William Derham,N/A,1713,https://openlibrary.org/works/OL5949084W
+Let The Circle be Unbroken,Mildred D. Taylor,N/A,1981,https://openlibrary.org/works/OL40864W
+The Overstory,Richard Powers,N/A,2018,https://openlibrary.org/works/OL19074847W
+Diper Overlode,Jeff Kinney,N/A,2014,https://openlibrary.org/works/OL27816605W
+Star Wars - Thrawn Trilogy - Dark Force Rising,Timothy Zahn,N/A,1992,https://openlibrary.org/works/OL83573W
+You Only Live Twice,Ian Fleming,N/A,1964,https://openlibrary.org/works/OL267791W
+Demon Slayer,Koyoharu Gotōge,N/A,2018,https://openlibrary.org/works/OL20153262W
+The Seven Spiritual Laws of Success,Deepak Chopra,N/A,1994,https://openlibrary.org/works/OL548626W
+Lessons in Chemistry,Bonnie Garmus,N/A,2022,https://openlibrary.org/works/OL25344431W
+Letters from a Stoic,Seneca the Younger,N/A,1969,https://openlibrary.org/works/OL102290W
+Star Born,Andre Norton,N/A,1957,https://openlibrary.org/works/OL473476W
+End of Watch,Stephen King,N/A,2000,https://openlibrary.org/works/OL17357373W
+Marge Piercy,"Marge Piercy, Tanya Eby",N/A,1976,https://openlibrary.org/works/OL87971W
+A week on the Concord and Merrimack Rivers,Henry David Thoreau,N/A,1849,https://openlibrary.org/works/OL55670W
+Guest List,"Lucy Foley, Victoria Horrillo Ledesma",N/A,2020,https://openlibrary.org/works/OL20742637W
+Sharpe's Tiger,"Bernard Cornwell, Frederick Davidson",N/A,1997,https://openlibrary.org/works/OL23309W
+The Red Fairy Book (Large Print),"Andrew Lang, Henry Justice Ford, Lancelot Speed",N/A,1890,https://openlibrary.org/works/OL1088858W
+The Body Keeps the Score,Bessel van der Kolk,N/A,2014,https://openlibrary.org/works/OL18147687W
+Experience and education,John Dewey,N/A,1938,https://openlibrary.org/works/OL111355W
+The Penderwicks,Jeanne Birdsall,N/A,2005,https://openlibrary.org/works/OL5717079W
+Think Like a Monk,Jay Shetty,N/A,2020,https://openlibrary.org/works/OL21237606W
+The adventures of Super Diaper Baby,Dav Pilkey,N/A,2002,https://openlibrary.org/works/OL6213633W
+The Source,James A. Michener,N/A,1900,https://openlibrary.org/works/OL2385455W
+On the Way to the Wedding,Julia Quinn,N/A,2006,https://openlibrary.org/works/OL554614W
+国境の南、太陽の西,村上春樹,N/A,1992,https://openlibrary.org/works/OL2625405W
+Midnight,Erin Hunter,N/A,2005,https://openlibrary.org/works/OL5714297W
+Dog Man,Dav Pilkey,N/A,2014,https://openlibrary.org/works/OL17922359W
+Grey,E. L. James,N/A,2015,https://openlibrary.org/works/OL17183968W
+The Blade Itself,Joe Abercrombie,N/A,2001,https://openlibrary.org/works/OL8400950W
+Amulet,Kazu Kibuishi,N/A,2008,https://openlibrary.org/works/OL8842598W
+Il formaggio e i vermi,"Carlo Ginzburg, Anne C. Tedeschi, John Tedeschi",N/A,1976,https://openlibrary.org/works/OL14872792W
+Compleat angler,Izaak Walton,N/A,1653,https://openlibrary.org/works/OL639908W
+A Journey to the Western Islands of Scotland,Samuel Johnson,N/A,1775,https://openlibrary.org/works/OL14862665W
+Red Rising,Pierce Brown,N/A,2014,https://openlibrary.org/works/OL17076473W
+Parable of the Talents,Octavia E. Butler,N/A,1998,https://openlibrary.org/works/OL35618W
+世界の終りとハードボイルド・ワンダーランド,村上春樹,N/A,1985,https://openlibrary.org/works/OL2625421W
+Rainbow six,Tom Clancy,N/A,1998,https://openlibrary.org/works/OL159621W
+Trois contes,Gustave Flaubert,N/A,1877,https://openlibrary.org/works/OL893957W
+The social animal,"Elliot Aronson, Elliot Aronson",N/A,1972,https://openlibrary.org/works/OL1589959W
+I Sing the Body Electric!,Ray Bradbury,N/A,1969,https://openlibrary.org/works/OL103156W
+The medical pocket-book,John Elliot,N/A,1784,https://openlibrary.org/works/OL7569062W
+Hannibal Rising,Thomas Harris,N/A,2006,https://openlibrary.org/works/OL138395W
+Origami,Robert Harbin,N/A,1968,https://openlibrary.org/works/OL1842278W
+Tuḥfat al-nuẓẓār fī gharāʾib al-amṣār wa-ʻajāʾib al-asfār,"Ibn Batuta, A. R. Gibb, H. A. R. Gibb",N/A,1829,https://openlibrary.org/works/OL43613W
+The Tipping Point,Malcolm Gladwell,N/A,2000,https://openlibrary.org/works/OL5749848W
+Misère de la philosophie,Karl Marx,N/A,1847,https://openlibrary.org/works/OL629046W
+Dream Country,"Neil Gaiman, Jill Thompson, Bryan Talbot",N/A,1991,https://openlibrary.org/works/OL14975232W
+Artemis Fowl and the Atlantis Complex,Eoin Colfer,N/A,2010,https://openlibrary.org/works/OL15279945W
+Vitae excellentium imperatorum,Cornelius Nepos,N/A,1594,https://openlibrary.org/works/OL3069840W
+The Magicians,Lev Grossman,N/A,2009,https://openlibrary.org/works/OL2679341W
+The Absolutely True Diary of a Part-Time Indian,Sherman Alexie,N/A,2007,https://openlibrary.org/works/OL46472W
+How Things Work,Louis A. Bloomfield,N/A,1995,https://openlibrary.org/works/OL8206804W
+Rosie's walk,Pat Hutchins,N/A,1967,https://openlibrary.org/works/OL18805W
+Meditation,Bhagwan Rajneesh,N/A,1970,https://openlibrary.org/works/OL11752W
+A New Earth,Eckhart Tolle,N/A,2005,https://openlibrary.org/works/OL5727685W
+The education of Henry Adams,Henry Adams,N/A,1777,https://openlibrary.org/works/OL24220W
+Silverwing,Kenneth Oppel,N/A,1997,https://openlibrary.org/works/OL19340W
+ダンス・ダンス・ダンス,村上春樹,N/A,1988,https://openlibrary.org/works/OL2625414W
+Stock Investing for Dummies,Paul Mladjenovic,N/A,2002,https://openlibrary.org/works/OL278197W
+Memoirs of a Revolutionist,Peter Kropotkin,N/A,1899,https://openlibrary.org/works/OL1105384W
+Out From Boneville,"Jeff Smith, Jeff Smith",N/A,1993,https://openlibrary.org/works/OL265609W
+Exile,Shannon Messenger,N/A,2012,https://openlibrary.org/works/OL17710016W
+The Dark Secret,Tui T. Sutherland,N/A,2013,https://openlibrary.org/works/OL27675460W
+Dealing with Dragons,Patricia C. Wrede,N/A,1990,https://openlibrary.org/works/OL2660331W
+Legendary,Stephanie Garber,N/A,2018,https://openlibrary.org/works/OL19748577W
+The Wicked King,"Holly Black, LAIPENG",N/A,2019,https://openlibrary.org/works/OL18543708W
+Kometen kommer (Kometjakten),Tove Jansson,N/A,1946,https://openlibrary.org/works/OL2195985W
+This Changes Everything,Naomi Klein,N/A,2013,https://openlibrary.org/works/OL17062332W
+Don Giovanni,Wolfgang Amadeus Mozart,N/A,1800,https://openlibrary.org/works/OL624289W
+Cell and Molecular Biology,Gerald Karp,N/A,1996,https://openlibrary.org/works/OL3269846W
+"Antonina, or, The fall of Rome",Wilkie Collins,N/A,1850,https://openlibrary.org/works/OL176059W
+Sounder,William H. Armstrong,N/A,1969,https://openlibrary.org/works/OL270979W
+Starlight,Erin Hunter,N/A,2006,https://openlibrary.org/works/OL5714312W
+Cold Fire,Dean Koontz,N/A,1991,https://openlibrary.org/works/OL497135W
+Stalingrad,Antony Beevor,N/A,1998,https://openlibrary.org/works/OL1881611W
+The Silk Roads,Peter Frankopan,N/A,2015,https://openlibrary.org/works/OL19666939W
+The Sicilian,Mario Puzo,N/A,1983,https://openlibrary.org/works/OL1673260W
+The Final Touch,Betty Neels,N/A,1991,https://openlibrary.org/works/OL3458028W
+Digital photography for dummies,Julie Adair King,N/A,1997,https://openlibrary.org/works/OL71938W
+The Siren,Kiera Cass,N/A,2009,https://openlibrary.org/works/OL14991775W
+The Peripheral,William Gibson,N/A,2014,https://openlibrary.org/works/OL17268037W
+Clotel,"William Wells Brown, M. Giulia Fabi",N/A,1853,https://openlibrary.org/works/OL515599W
+Novels (Screwtape Letters / Screwtape Proposes a Toast),C.S. Lewis,N/A,1955,https://openlibrary.org/works/OL15095540W
+The Westing Game,Ellen Raskin,N/A,1978,https://openlibrary.org/works/OL4103857W
+The art of computer programming,Donald Knuth,N/A,1968,https://openlibrary.org/works/OL257263W
+Malibu Rising,Taylor Jenkins Reid,N/A,2021,https://openlibrary.org/works/OL22135561W
+Pollyanna Grows Up,Eleanor Hodgman Porter,N/A,1915,https://openlibrary.org/works/OL2775806W
+Asesino Real,"Robin Hobb, Arnaud Mousnier-Lompré",N/A,1996,https://openlibrary.org/works/OL2707184W
+Zanoni,"Edward Bulwer Lytton, Baron Lytton",N/A,1842,https://openlibrary.org/works/OL61849W
+The hero with a thousand faces,Joseph Campbell,N/A,1949,https://openlibrary.org/works/OL2497175W
+Story,Robert McKee,N/A,1997,https://openlibrary.org/works/OL273896W
+Caliban's war,James S. A. Corey,N/A,2012,https://openlibrary.org/works/OL16117275W
+The  day's work,Rudyard Kipling,N/A,1898,https://openlibrary.org/works/OL20162W
+Interaction of Colour,Joseph Albers,N/A,1963,https://openlibrary.org/works/OL2286161W
+Adam of the road,Elizabeth Gray Vining,N/A,1942,https://openlibrary.org/works/OL4970283W
+Am Ufer des Rio Piedra saß ich und weinte,"Paulo Coelho, Alfonso Indecona",N/A,1975,https://openlibrary.org/works/OL796473W
+Fallen angels,Walter Dean Myers,N/A,1984,https://openlibrary.org/works/OL98267W
+Alcatraz versus the Evil Librarians,Brandon Sanderson,N/A,2007,https://openlibrary.org/works/OL5738144W
+Peppa Pig,Peppa Pig,N/A,2012,https://openlibrary.org/works/OL20156081W
+Free air,Sinclair Lewis,N/A,1919,https://openlibrary.org/works/OL51142W
+Fascinating womanhood,"Helen B. Andelin, Helen Andelin, Helen B. Andelin",N/A,1963,https://openlibrary.org/works/OL3071178W
+How to Catch a Star,Oliver Jeffers,N/A,2004,https://openlibrary.org/works/OL5823163W
+Girl in Pieces,Kathleen Glasgow,N/A,2000,https://openlibrary.org/works/OL20234863W
+The loom of language,Frederick Bodmer,N/A,1943,https://openlibrary.org/works/OL809626W
+Outcast,Erin Hunter,N/A,2008,https://openlibrary.org/works/OL5714309W
+Confessions of a Mask,"三島由紀夫, Meredith Weatherby",N/A,1958,https://openlibrary.org/works/OL1845165W
+The Free Fishers,John Buchan,N/A,1934,https://openlibrary.org/works/OL76573W
+A wanted man,Lee Child,N/A,2012,https://openlibrary.org/works/OL16646027W
+Smoke and Mirrors,"Neil Gaiman, Richard Chizmar, William Peter Blatty, Kealan Patrick Burke, Brian Keene, Joe Hill, Joe R. Lansdale, Ray Garton",N/A,1998,https://openlibrary.org/works/OL679357W
+Burning Chrome,William Gibson,N/A,1986,https://openlibrary.org/works/OL27254W
+Poirot's Early Cases,Agatha Christie,N/A,1963,https://openlibrary.org/works/OL471915W
+The Diary of a Young Girl- Anne Frank,Anne Frank,N/A,2001,https://openlibrary.org/works/OL27294413W
+Between Shades of Gray,Ruta Sepetys,N/A,1999,https://openlibrary.org/works/OL15749193W
+Soil Capability For Agriculture,Canada Land Inventory.,N/A,1965,https://openlibrary.org/works/OL6188591W
+South Wind - Norman Douglas,"Norman Douglas, Norman Douglas, Norman (1868-1952) Douglas, Norman [1868 - 1952] Douglas, NORMAN DOUGLAS, Douglas, Norman Petrina, Carlotta,, Douglas, Norman and Angelo, Valenti (Illus. ), norman douglas",N/A,1900,https://openlibrary.org/works/OL3335380W
+Murtagh,Christopher Paolini,N/A,2023,https://openlibrary.org/works/OL34957950W
+"Novels (Hitch Hiker's Guide to the Galaxy / Restaurant at the End of the Universe / Life, the Universe and Everything / So Long, and Thanks for All the Fish)",Douglas Adams,N/A,1979,https://openlibrary.org/works/OL2163690W
+"Black Hawk, Down",Mark Bowden,N/A,1999,https://openlibrary.org/works/OL491846W
+On food and cooking,Harold McGee,N/A,1984,https://openlibrary.org/works/OL4110479W
+The Shallows,Nicholas Carr,N/A,2010,https://openlibrary.org/works/OL15297392W
+The ballad of the white horse,"Gilbert Keith Chesterton, Catholic Way Publishing Staff",N/A,1911,https://openlibrary.org/works/OL76455W
+The Lies of Locke Lamora,Scott Lynch,N/A,2001,https://openlibrary.org/works/OL8369445W
+Anthropology,Carol R. Ember,N/A,1973,https://openlibrary.org/works/OL1829859W
+The golden goblet,"Eloise Jarvis McGraw, Charles Carroll",N/A,1961,https://openlibrary.org/works/OL2951038W
+The Psychology of Everyday Things,Donald A. Norman,N/A,1988,https://openlibrary.org/works/OL1879162W
+Romancing Mister Bridgerton,Julia Quinn,N/A,2002,https://openlibrary.org/works/OL554615W
+The minds of Billy Milligan,Daniel Keyes,N/A,1981,https://openlibrary.org/works/OL515765W
+Le dossier no. 113,Émile Gaboriau,N/A,1868,https://openlibrary.org/works/OL1546085W
+On the shortness of life,Seneca the Younger,N/A,2005,https://openlibrary.org/works/OL15222991W
+Filsafat ilmu,"The, Liang Gie.",N/A,2005,https://openlibrary.org/works/OL16538595W
+Janson's history of art,"H. W. Janson, Penelope J. E. Davies, Walter B. Denny, Frima Fox Hofrichter, Joseph F. Jacobs, Ann M. Roberts, David L. Simon",N/A,2006,https://openlibrary.org/works/OL1719852W
+Please Look After Mom,Kyong-suk Sin,N/A,2000,https://openlibrary.org/works/OL15702773W
+The knife of never letting go,"Patrick Ness, Nick Podehl",N/A,2008,https://openlibrary.org/works/OL6073271W
+The Human Zoo,Desmond Morris,N/A,1705,https://openlibrary.org/works/OL104152W
+A Voyage to Arcturus,"David Lindsay, David Lindsay",N/A,1920,https://openlibrary.org/works/OL235280W
+Gratitude Journal for Kids,Motwani Dev Motwani Dev Publishing,N/A,2021,https://openlibrary.org/works/OL25592008W
+The New Girl,Robert Lawrence Stine,N/A,1989,https://openlibrary.org/works/OL72313W
+The Greatest Secret in the World,Og Mandino,N/A,1972,https://openlibrary.org/works/OL2642710W
+The 33 Strategies of War,"Robert Greene, Don Leslie",N/A,1998,https://openlibrary.org/works/OL9290241W
+Beauty's release,Anne Rice,N/A,1985,https://openlibrary.org/works/OL5473519W
+El conde Lucanor,Don Juan Manuel,N/A,1839,https://openlibrary.org/works/OL249192W
+Aristotle and Dante discover the secrets of the universe,Benjamin Alire Sáenz,N/A,2012,https://openlibrary.org/works/OL16596099W
+Flashback,Shannon Messenger,N/A,2012,https://openlibrary.org/works/OL17938213W
+The woman warrior,Maxine Hong Kingston,N/A,1976,https://openlibrary.org/works/OL1822441W
+The Doorbell Rang,Pat Hutchins,N/A,1986,https://openlibrary.org/works/OL18803W
+The Doll's House,"Neil Gaiman, Kelley Jones, Mike Dringenberg, Kelly Jones",N/A,1991,https://openlibrary.org/works/OL15449786W
+The Yellow House Mystery,Gertrude Chandler Warner,N/A,1953,https://openlibrary.org/works/OL15143W
+The Winter King,Bernard Cornwell,N/A,1995,https://openlibrary.org/works/OL23272W
+Drama des begabten Kindes,Alice Miller,N/A,1981,https://openlibrary.org/works/OL15464347W
+Chocolate Touch,Patrick Skene Catling,N/A,1952,https://openlibrary.org/works/OL5258936W
+The way of the superior man,David Deida,N/A,1997,https://openlibrary.org/works/OL2680142W
+The Vanishing Half,Brit Bennett,N/A,2020,https://openlibrary.org/works/OL20799434W
+Rikki-Tikki-Tavi,Rudyard Kipling,N/A,1893,https://openlibrary.org/works/OL20139W
+Mexican Gothic,Silvia Moreno-Garcia,N/A,2020,https://openlibrary.org/works/OL20759125W
+The doors of perception,Aldous Huxley,N/A,1954,https://openlibrary.org/works/OL64441W
+The lost boy,David J. Pelzer,N/A,1994,https://openlibrary.org/works/OL66944W
+The rescue,Nicholas Sparks,N/A,2000,https://openlibrary.org/works/OL54817W
+Through the Magic Door,Arthur Conan Doyle,N/A,1907,https://openlibrary.org/works/OL262572W
+"The sorrows of Satan, or, The strange experience of one Geoffrey Tempest, millionaire ; a romance","Marie Corelli, Ardeshir Eyzdagird",N/A,1895,https://openlibrary.org/works/OL1487943W
+Bracebridge Hall,Washington Irving,N/A,1800,https://openlibrary.org/works/OL63915W
+An ember in the ashes,Sabaa Tahir,N/A,2015,https://openlibrary.org/works/OL17786115W
+An Offer from a Gentleman,Julia Quinn,N/A,2001,https://openlibrary.org/works/OL554608W
+Ready Player Two,Ernest Cline,N/A,2019,https://openlibrary.org/works/OL20907281W
+Faith of the Fallen,Terry Goodkind,N/A,2000,https://openlibrary.org/works/OL2010452W
+Dress pattern designing,Natalie Bray,N/A,1961,https://openlibrary.org/works/OL6044966W
+Amore alla corte degli zar,Elisabetta Dami,N/A,1900,https://openlibrary.org/works/OL17209694W
+The Silver Eyes (Five Nights At Freddy's #1),"Scott Cawthon, Kira Breed-Wrisley, Suzanne Elise Freeman",N/A,2001,https://openlibrary.org/works/OL17793648W
+The School for Good and Evil,Soman Chainani,N/A,2007,https://openlibrary.org/works/OL16810944W
+Lioness Rampant,Tamora Pierce,N/A,1988,https://openlibrary.org/works/OL29251W
+The Brightest Night,Tui T. Sutherland,N/A,2014,https://openlibrary.org/works/OL17832521W
+Nightfall,Shannon Messenger,N/A,2017,https://openlibrary.org/works/OL17714997W
+The Anarchist Cookbook,"William F. Powell, William Powell, William Powell",N/A,1971,https://openlibrary.org/works/OL2347897W
+First They Killed My Father,Loung Ung,N/A,2000,https://openlibrary.org/works/OL5732697W
+Dieu et l’État,Mikhail Aleksandrovich Bakunin,N/A,1882,https://openlibrary.org/works/OL26823929W
+The Talisman,Sir Walter Scott,N/A,1800,https://openlibrary.org/works/OL863795W
+Il tesoro di ghiaccio,Elisabetta Dami,N/A,1900,https://openlibrary.org/works/OL16812986W
+Mindset,Carol S. Dweck,N/A,2006,https://openlibrary.org/works/OL2003465W
+Imagined communities,Benedict Anderson,N/A,1983,https://openlibrary.org/works/OL1702855W
+Fiela se kind,Dalene Matthee,N/A,1985,https://openlibrary.org/works/OL2412102W
+Tuck Everlasting,Natalie Babbitt,N/A,1975,https://openlibrary.org/works/OL2775698W
+Kwaidan,Lafcadio Hearn,N/A,1904,https://openlibrary.org/works/OL859613W
+The mirror of the sea,Joseph Conrad,N/A,1906,https://openlibrary.org/works/OL39096W
+Darkly dreaming Dexter,Jeffry P. Lindsay,N/A,2004,https://openlibrary.org/works/OL3968346W
+Secrets of the Millionaire Mind,T. Harv Eker,N/A,2005,https://openlibrary.org/works/OL275915W
+The Wolf and the Dove,Kathleen E. Woodiwiss,N/A,1974,https://openlibrary.org/works/OL59382W
+The Joys of Motherhood,"B. Emecheta, Buchi Emecheta, Buchi Emecheta",N/A,1979,https://openlibrary.org/works/OL2504658W
+Ricky Ricotta's Mighty Robot #1,Dav Pilkey,N/A,2000,https://openlibrary.org/works/OL9741466W
+The Right Stuff,Tom Wolfe,N/A,1979,https://openlibrary.org/works/OL1925474W
+The Sheik,E. M. Hull,N/A,1919,https://openlibrary.org/works/OL6101936W
+The Windup Girl,Paolo Bacigalupi,N/A,2009,https://openlibrary.org/works/OL15000756W
+They Both Die at the End,Adam Silvera,N/A,2017,https://openlibrary.org/works/OL19713513W
+God Help the Child,Toni Morrison,N/A,2015,https://openlibrary.org/works/OL17333633W
+Before the Coffee Gets Cold,川口俊和,N/A,2019,https://openlibrary.org/works/OL20832477W
+The Chalk Man,C. J. Tudor,N/A,2017,https://openlibrary.org/works/OL19333591W
+After You,"Jojo Moyes, Yujia He",N/A,2014,https://openlibrary.org/works/OL17364681W
+A Knight of the Seven Kingdoms,George R. R. Martin,N/A,2013,https://openlibrary.org/works/OL17553509W
+Two for the dough,Janet Evanovich,N/A,1996,https://openlibrary.org/works/OL48061W
+Fundamentals of biochemistry,"Donald Voet, Judith G. Voet, Charlotte W. Pratt",N/A,1999,https://openlibrary.org/works/OL1898003W
+Hideaway,Dean Koontz,N/A,1992,https://openlibrary.org/works/OL263239W
+Dark Lover,J. R. Ward,N/A,2005,https://openlibrary.org/works/OL5091273W
+The Brilliant World of Tom Gates,Liz Pichon,N/A,2011,https://openlibrary.org/works/OL17427523W
+Lateral thinking: creativity step by step,"Edward de Bono, Traductores varios, Alexandre Gombau Armau",N/A,1970,https://openlibrary.org/works/OL675408W
+Moreta,Anne McCaffrey,N/A,1983,https://openlibrary.org/works/OL73386W
+Ayesha,H. Rider Haggard,N/A,1900,https://openlibrary.org/works/OL17440W
+Gangsta Granny,"David Walliams, Tony Ross",N/A,2008,https://openlibrary.org/works/OL24800468W
+Where is the green sheep?,"Mem Fox, Judy Horacek",N/A,2004,https://openlibrary.org/works/OL650958W
+In the garden of beasts,Erik Larson,N/A,2011,https://openlibrary.org/works/OL15738124W
+Drive,Daniel H. Pink,N/A,2009,https://openlibrary.org/works/OL15016965W
+Big Nate in the Zone,Lincoln Peirce,N/A,2007,https://openlibrary.org/works/OL17534061W
+The Son of the Wolf,Jack London,N/A,1900,https://openlibrary.org/works/OL144817W
+Twilight,Erin Hunter,N/A,2006,https://openlibrary.org/works/OL5714319W
+A Tangled Tale,Lewis Carroll,N/A,1881,https://openlibrary.org/works/OL151445W
+I Will Repay,"Emmuska Orczy, Baroness Orczy",N/A,1900,https://openlibrary.org/works/OL286343W
+The Dream Within,Barbara Cartland,N/A,1947,https://openlibrary.org/works/OL137163W
+Dispatches,Michael Herr,N/A,1977,https://openlibrary.org/works/OL4482600W
+My inventions,Nikola Tesla,N/A,1977,https://openlibrary.org/works/OL71633W
+The Merchant of Death (Pendragon #1),D. J. MacHale,N/A,2002,https://openlibrary.org/works/OL4086564W
+Hide and Seek,James Patterson,N/A,1986,https://openlibrary.org/works/OL167159W
+Nine Coaches Waiting,Mary Stewart,N/A,1958,https://openlibrary.org/works/OL213266W
+La porte étroite,"André Gide, Dorothy Bussy, Blanca Torrents",N/A,1907,https://openlibrary.org/works/OL631009W
+Flora & Ulysses,Kate DiCamillo,N/A,2013,https://openlibrary.org/works/OL16811465W
+Annie John,"Jamaica Kincaid, Annie John",N/A,1983,https://openlibrary.org/works/OL2664661W
+Sunrise,Erin Hunter,N/A,2009,https://openlibrary.org/works/OL14906962W
+Psychology,Robert A. Baron,N/A,1977,https://openlibrary.org/works/OL2661659W
+Ivanhoe,Sir Walter Scott,N/A,1820,https://openlibrary.org/works/OL25852013W
+Roadside Picnic,"Аркадий Натанович Стругацкий, Борис Натанович Стругацкий",N/A,1978,https://openlibrary.org/works/OL7967812W
+Paddle-to-the-Sea,Holling Clancy Holling,N/A,1941,https://openlibrary.org/works/OL4528062W
+The land of mist,Arthur Conan Doyle,N/A,1926,https://openlibrary.org/works/OL262551W
+Moneyball,Michael Lewis,N/A,2003,https://openlibrary.org/works/OL7944813W
+Tinker Tailor Soldier Spy,John le Carré,N/A,1974,https://openlibrary.org/works/OL15723131W
+Rising Sun,Michael Crichton,N/A,1991,https://openlibrary.org/works/OL46887W
+Tartarín de Tarascón,"Alphonse Daudet, Carlos Cantueso, Bookstore, Tite Fée Tite Fée édition, Oliver C. Colt.",N/A,1800,https://openlibrary.org/works/OL942448W
+Steelheart,Brandon Sanderson,N/A,2001,https://openlibrary.org/works/OL16807297W
+Violeta,Isabel Allende,N/A,2022,https://openlibrary.org/works/OL24492424W
+Bröderna Lejonhjärta,Astrid Lindgren,N/A,1973,https://openlibrary.org/works/OL14872846W
+Thirteen reasons Why,Jay Asher,N/A,2007,https://openlibrary.org/works/OL9264548W
+Scary Stories 3,Alvin Schwartz,N/A,1991,https://openlibrary.org/works/OL273689W
+The Sympathizer,"Viet Thanh Nguyen, Francois Chau",N/A,2015,https://openlibrary.org/works/OL17345497W
+Dog Man,Dav Pilkey,N/A,1999,https://openlibrary.org/works/OL17798838W
+Ordinary Men,Christopher R. Browning,N/A,1992,https://openlibrary.org/works/OL85351W
+King Leopold's ghost,"Adam Hochschild, GIL ARISTU JOSE LUIS,",N/A,1998,https://openlibrary.org/works/OL1869541W
+It's Perfectly Normal,"Robie H. Harris, Michael Ill Emberley, Michael Emberley",N/A,1994,https://openlibrary.org/works/OL42649W
+"Right Ho, Jeeves",P. G. Wodehouse,N/A,1934,https://openlibrary.org/works/OL1337129W
+The Definitive Book of Body Language,"Allan Pease, Barbara Pease",N/A,2004,https://openlibrary.org/works/OL5599445W
+Ai hen chih chien,"Susan Forward, Joan Torres",N/A,1986,https://openlibrary.org/works/OL1929396W
+A Slow Regard of Silent Things,Patrick Rothfuss,N/A,2014,https://openlibrary.org/works/OL17067388W
+The Visual Display of Quantitative Information,Edward R. Tufte,N/A,1983,https://openlibrary.org/works/OL2824012W
+The National Health Service (General Dental Services) Amendment (no.2) Regulations 1988,Rand McNally,N/A,1974,https://openlibrary.org/works/OL14903348W
+Preludes & Nocturnes,"Neil Gaiman, Sam Kieth",N/A,1991,https://openlibrary.org/works/OL9200964W
+A people's tragedy,Orlando Figes,N/A,1996,https://openlibrary.org/works/OL72141W
+QED,"Richard Phillips Feynman, A. Zee",N/A,1985,https://openlibrary.org/works/OL271757W
+Philosophische Untersuchungen,Ludwig Wittgenstein,N/A,1953,https://openlibrary.org/works/OL1410380W
+The Kiss Quotient,Helen Hoang,N/A,2018,https://openlibrary.org/works/OL19744698W
+The Orphan Master's Son,Adam Johnson,N/A,2012,https://openlibrary.org/works/OL16419990W
+The Enjoyment of Music,"Kristine Forney, Andrew Dell'Antonio, Joseph Machlis",N/A,1996,https://openlibrary.org/works/OL4466706W
+Il Vascello Fantasma,Elisabetta Dami,N/A,2007,https://openlibrary.org/works/OL15168086W
+The Song of the Lark,Willa Cather,N/A,1915,https://openlibrary.org/works/OL12831W
+The Mayor of Casterbridge,"Thomas Hardy, Martin Seymour-Smith, Anonymous, Edgar Allan Poe, Joseph Jacobs, John Tidball",N/A,1800,https://openlibrary.org/works/OL8193406W
+The Regulators,Stephen King,N/A,1996,https://openlibrary.org/works/OL2794726W
+Charmed Life,Diana Wynne Jones,N/A,1977,https://openlibrary.org/works/OL60091W
+The Short Second Life of Bree Tanner,Stephenie Meyer,N/A,2009,https://openlibrary.org/works/OL15166934W
+Coloring Book,Coloring book,N/A,2019,https://openlibrary.org/works/OL30280651W
+Psychology,William James,N/A,1892,https://openlibrary.org/works/OL1502063W
+Homeland,R. A. Salvatore,N/A,1990,https://openlibrary.org/works/OL516681W
+Prince,Niccolò Machiavelli,N/A,1998,https://openlibrary.org/works/OL21456413W
+The Camel Club,David Baldacci,N/A,2005,https://openlibrary.org/works/OL41247W
+De Occulta Philosophia,Heinrich Cornelius Agrippa von Nettesheim,N/A,1533,https://openlibrary.org/works/OL1114830W
+One-Dimensional Man,Herbert Marcuse,N/A,1963,https://openlibrary.org/works/OL98205W
+Amusing Ourselves to Death,"Neil Postman, Neil Postman",N/A,1985,https://openlibrary.org/works/OL137916W
+The Inner Game of Tennis,W. Timothy Gallwey,N/A,1834,https://openlibrary.org/works/OL2619508W
+Amulet,Kazu Kibuishi,N/A,2009,https://openlibrary.org/works/OL15728504W
+Five Go to Smuggler's Top,Enid Blyton,N/A,1945,https://openlibrary.org/works/OL1948513W
+Roald Dahl Treasury,"Roald Dahl, Quentin Blake",N/A,1997,https://openlibrary.org/works/OL45861W
+The Pact,Jodi Picoult,N/A,1998,https://openlibrary.org/works/OL891953W
+The farming of bones,Edwidge Danticat,N/A,1998,https://openlibrary.org/works/OL1806966W
+The Architecture of Happiness,Alain De Botton,N/A,2006,https://openlibrary.org/works/OL107927W
+Me on the map,Joan Sweeney,N/A,1996,https://openlibrary.org/works/OL15844035W
+Living the 7 Habits,Stephen R. Covey,N/A,1999,https://openlibrary.org/works/OL2630080W
+Skyward,Brandon Sanderson,N/A,2018,https://openlibrary.org/works/OL18191919W
+These Truths,Jill Lepore,N/A,2018,https://openlibrary.org/works/OL18201116W
+Less,Andrew Sean Greer,N/A,2017,https://openlibrary.org/works/OL19710804W
+Fantastic Fables,Ambrose Bierce,N/A,1899,https://openlibrary.org/works/OL7973284W
+The one minute manager,"Kenneth H. Blanchard, Spencer Johnson, Kenneth Blanchard",N/A,1981,https://openlibrary.org/works/OL66049W
+We Should All Be Feminists,Chimamanda Ngozi Adichie,N/A,2014,https://openlibrary.org/works/OL17319838W
+Houghton Mifflin Science Leveled Readers,Houghton Mifflin Company Staff,N/A,2005,https://openlibrary.org/works/OL27467443W
+The Cuckoo’s Egg,Clifford Stoll,N/A,1989,https://openlibrary.org/works/OL3741565W
+Anna of the Five Towns,Arnold Bennett,N/A,1902,https://openlibrary.org/works/OL109233W
+Helter Skelter,"Vincent Bugliosi, Curt Gentry",N/A,1974,https://openlibrary.org/works/OL2588975W
+The Scorch Trials,James Dashner,N/A,2010,https://openlibrary.org/works/OL15414803W
+American practical navigator,"Nathaniel Bowditch, Philip Henry Cooper, United States. Bureau of Naval Personnel, George Wood Logan, United States. Navy Dept. Bureau of Equi, National Imagery and Mapping Agency, National Geospatial-Intelligence Agency (U.S.), Jonathan Ingersoll Bowditch, Nima, United States Navy Department Hydrographic Office",N/A,1802,https://openlibrary.org/works/OL4256463W
+The Starless Sea,Erin Morgenstern,N/A,2019,https://openlibrary.org/works/OL20416941W
+Screenplay,Syd Field,N/A,1979,https://openlibrary.org/works/OL15845018W
+Unnatural Death,Dorothy L. Sayers,N/A,1927,https://openlibrary.org/works/OL2234912W
+The seven principles for making marriage work,"John Mordechai Gottman, Nan Silver, Eric Michael Summerer",N/A,1999,https://openlibrary.org/works/OL1982054W
+Fear Street - The Overnight,Robert Lawrence Stine,N/A,1989,https://openlibrary.org/works/OL480105W
+Basic economics,Thomas Sowell,N/A,2000,https://openlibrary.org/works/OL1935800W
+The Warmth of Other Suns,Isabel Wilkerson,N/A,2010,https://openlibrary.org/works/OL15380640W
+Skipping Christmas,John Grisham,N/A,2001,https://openlibrary.org/works/OL76976W
+The Book of Dreams and Ghosts (Large Print),Andrew Lang,N/A,1897,https://openlibrary.org/works/OL1088777W
+Ways of Seeing,John Berger,N/A,1972,https://openlibrary.org/works/OL1980231W
+Persepolis,Marjane Satrapi,N/A,2000,https://openlibrary.org/works/OL5735175W
+The Paris Apartment,Lucy Foley,N/A,2020,https://openlibrary.org/works/OL24783640W
+Sackett's Land,Louis L'Amour,N/A,1973,https://openlibrary.org/works/OL50933W
+The Fifth Discipline,"Peter Senge, Peter M. Senge",N/A,1990,https://openlibrary.org/works/OL4440692W
+The Thief,Megan Whalen Turner,N/A,1996,https://openlibrary.org/works/OL14872532W
+The Case of Jennie Brice,Mary Roberts Rinehart,N/A,1915,https://openlibrary.org/works/OL137389W
+The Fifth Season,N. K. Jemisin,N/A,2015,https://openlibrary.org/works/OL17363125W
+The Greatest Miracle in the World,Og Mandino,N/A,1975,https://openlibrary.org/works/OL2642707W
+The Courage to Be Disliked,"Ichirō Kishimi, Fumitake Koga, Ichiro Kishimi, Fumitake Koga Ichiro Kishimi, Montserrat Asensio Fernández",N/A,2013,https://openlibrary.org/works/OL19744000W
+Just Mercy,Bryan Stevenson,N/A,1600,https://openlibrary.org/works/OL17231441W
+Zodiac,Robert Graysmith,N/A,1986,https://openlibrary.org/works/OL2728912W
+Agente Secreto Zero Zero Kappa,Elisabetta Dami,N/A,2004,https://openlibrary.org/works/OL13730336W
+House of the Vampire Illustrated,George Sylvester Viereck,N/A,2019,https://openlibrary.org/works/OL21894618W
+Propaganda,Edward L. Bernays,N/A,1928,https://openlibrary.org/works/OL2781905W
+Master of the Game,Sidney Sheldon,N/A,1982,https://openlibrary.org/works/OL1881767W
+The Midnight Library,Matt Haig,N/A,2020,https://openlibrary.org/works/OL20965973W
+Hitchcock,"François Truffaut, Alfred Hitchcock, Helen G. Scott",N/A,1966,https://openlibrary.org/works/OL3477651W
+The Boy in the Dress,David Walliams,N/A,2008,https://openlibrary.org/works/OL15176554W
+The art of electronics,"Paul Horowitz, Winfield Hill",N/A,1980,https://openlibrary.org/works/OL4770496W
+All the Bright Places,Jennifer Niven,N/A,2015,https://openlibrary.org/works/OL17323489W
+Bouvard et Pécuchet,Gustave Flaubert,N/A,1896,https://openlibrary.org/works/OL893601W
+Dragons of Winter Night,"Margaret Weis, Tracy Hickman, Paul Boehmer",N/A,1985,https://openlibrary.org/works/OL73412W
+Track Edition Uk,Louise Erdrich,N/A,1988,https://openlibrary.org/works/OL479024W
+Redeeming Love,Francine Rivers,N/A,1991,https://openlibrary.org/works/OL21435W
+Housing,United States. Bureau of the Census,N/A,1942,https://openlibrary.org/works/OL15207281W
+Novel,Serajul ISLAM,N/A,2020,https://openlibrary.org/works/OL30573385W
+The Body,Stephen King,N/A,1988,https://openlibrary.org/works/OL149108W
+Il Segreto Della Famiglia Tenebrax,"Elisabetta Dami, Koldo Biguri, Manuel Manzano, David Nel·lo",N/A,2002,https://openlibrary.org/works/OL8115834W
+The Lively Art of Writing,Lucile Vaughan Payne,N/A,1965,https://openlibrary.org/works/OL6151392W
+The Cinderella complex,Colette Dowling,N/A,1981,https://openlibrary.org/works/OL2749002W
+Artemis Fowl and the Time Paradox,Eoin Colfer,N/A,2008,https://openlibrary.org/works/OL5725955W
+The war that Saved my Life,Kimberly Brubaker Bradley,N/A,2015,https://openlibrary.org/works/OL17332150W
+Obasan,Joy Kogawa,N/A,1981,https://openlibrary.org/works/OL3189372W
+The Sixth Extinction,"Elizabeth Kolbert, Marcel Blanc",N/A,2014,https://openlibrary.org/works/OL16820830W
+Wulf the Saxon,G. A. Henty,N/A,1894,https://openlibrary.org/works/OL1794671W
+"The Fork, the Witch, and the Worm","Christopher Paolini, Angela Paolini",N/A,2018,https://openlibrary.org/works/OL19680664W
+The Two Dead Girls,Stephen King,N/A,1996,https://openlibrary.org/works/OL149165W
+The Hundred Thousand Kingdoms,N. K. Jemisin,N/A,2010,https://openlibrary.org/works/OL13731150W
+Arcanum Unbounded,Brandon Sanderson,N/A,2016,https://openlibrary.org/works/OL17770504W
+The Crown (The Selection #5),Kiera Cass,N/A,2016,https://openlibrary.org/works/OL17356843W
+Nudge,"Richard H. Thaler, Cass R. Sunstein",N/A,2008,https://openlibrary.org/works/OL3936258W
+Journal,PlainSimpleBooks,N/A,2016,https://openlibrary.org/works/OL21986373W
+How to Win Friends and Influence People in the Digital Age,The Dale Carnegie Organization,N/A,2011,https://openlibrary.org/works/OL20429311W
+Mail Tracker,James Mayeaux,N/A,2022,https://openlibrary.org/works/OL28546806W
+The Dark Descent,"David G. Hartwell, Stephen King, John Collier, Montague Rhodes James, Lucy Clifford, Russell Kirk, H.P. Lovecraft, Shirley Jackson, Harlan Ellison, Nathaniel Hawthorne, Ray Bradbury, Michael Shea, Edith Nesbit, Karl Edward Wagner, Robert Aickman, Fritz Leiber, Robert Bloch, Charles L. Grant, Manly Wade Wellman, Thomas M. Disch, Theodore Sturgeon, Clive Barker, Edgar Allan Poe, Sheridan Le Fanu, Charlotte Perkins Gilman, William Faulkner, Robert Smythe Hichens, Richard Matheson, Joanna Russ, Dennis Etchison, D. H. Lawrence, Tanith Lee, Flannery O'Connor, Ramsey Campbell, Henry James, Gene Wolfe, Charles Dickens, Joyce Carol Oates, Walter De la Mare, Ivan Turguenev, Robert Chambers, Oliver Onions, Fitz-James O'Brien, Ambrose Bierce, Edith Wharton, Algernon Blackwood, Philip K. Dick",N/A,1987,https://openlibrary.org/works/OL2989350W
+Walking,Henry David Thoreau,N/A,1914,https://openlibrary.org/works/OL55719W
+An Arabian Mistress,Lynne Graham,N/A,2001,https://openlibrary.org/works/OL3773890W
+Saint Joan,George Bernard Shaw,N/A,1924,https://openlibrary.org/works/OL15151190W
+A Blunt Instrument,Georgette Heyer,N/A,1938,https://openlibrary.org/works/OL4092518W
+Big Nate Makes the Grade,Lincoln Peirce,N/A,2012,https://openlibrary.org/works/OL16797372W
+The 4-Hour Work Week,Timothy Ferriss,N/A,2006,https://openlibrary.org/works/OL8553062W
+A Tale for the Time Being,Ruth Ozeki,N/A,2013,https://openlibrary.org/works/OL17267887W
+Eleven Minutes,Paulo Coelho,N/A,2003,https://openlibrary.org/works/OL796601W
+The City of Brass,Shannon A. Chakraborty,N/A,2017,https://openlibrary.org/works/OL19623241W
+The Lost Apothecary,Sarah Penner,N/A,2021,https://openlibrary.org/works/OL21917209W
+Percy Jackson and the Olympians Hardcover Boxed Set,"Rick Riordan, John Rocco",N/A,2009,https://openlibrary.org/works/OL14955042W
+Brief Answers to the Big Questions,Stephen Hawking,N/A,2014,https://openlibrary.org/works/OL19552275W
+Season of Mists,"Neil Gaiman, Marc Hempel, Michael Zulli",N/A,1991,https://openlibrary.org/works/OL14975242W
+A Guide to the Project Management Body of Knowledge (PMBOK® Guide),Project Management Institute,N/A,1996,https://openlibrary.org/works/OL102817W
+Jewels of the Sun,Nora Roberts,N/A,1999,https://openlibrary.org/works/OL111573W
+Last Man Standing,David Baldacci,N/A,2001,https://openlibrary.org/works/OL41254W
+Project Hail Mary,Andy Weir,N/A,2021,https://openlibrary.org/works/OL21745884W
+A Swiftly Tilting Planet (Time Quintet #3),Madeleine L'Engle,N/A,1978,https://openlibrary.org/works/OL41492W
+The Arabian Nights Entertainments,"Andrew Lang, Abraham McDonald",N/A,1898,https://openlibrary.org/works/OL1088981W
+Goosebumps - One Day at Horrorland,"Robert Lawrence Stine, Scheherezade Suria",N/A,1994,https://openlibrary.org/works/OL72392W
+アフターダーク,村上春樹,N/A,2004,https://openlibrary.org/works/OL2625402W
+If Tomorrow Comes,Sidney Sheldon,N/A,1984,https://openlibrary.org/works/OL10640705W
+The Ministry for the Future,"Kim Stanley Robinson, Simon Saito",N/A,2020,https://openlibrary.org/works/OL21680947W
+The Power of Habit,Charles Duhigg,N/A,2012,https://openlibrary.org/works/OL16015154W
+Exit West,Mohsin Hamid,N/A,2017,https://openlibrary.org/works/OL17635446W
+1491,"Charles C. Mann, Charles Mann",N/A,2005,https://openlibrary.org/works/OL3494320W
+Graphic Design School,David Dabner,N/A,2004,https://openlibrary.org/works/OL5716312W
+The lives of the XII. Cæsars,"Suetonius, R. E. J. Fitzpatrick",N/A,1470,https://openlibrary.org/works/OL812798W
+La meta,"Eliyahu M. Goldratt, Jeff Cox",N/A,1984,https://openlibrary.org/works/OL2463054W
+The Baby-Sitter,Robert Lawrence Stine,N/A,1989,https://openlibrary.org/works/OL72364W
+An echo in the darkness,Francine Rivers,N/A,1994,https://openlibrary.org/works/OL13015026W
+A history of God,Karen Armstrong,N/A,1993,https://openlibrary.org/works/OL3280815W
+L'Heptaméron,"Marguerite Queen, consort of Henry II, King of Navarre",N/A,1740,https://openlibrary.org/works/OL1147931W
+The Sun Trail,Erin Hunter,N/A,2013,https://openlibrary.org/works/OL17413243W
+Nothing's Fair in Fifth Grade,Barthe DeClements,N/A,1981,https://openlibrary.org/works/OL2669100W
+The Practice of English Language Teaching,"Jeremy Harmer, J. Harmer, Jeremy Harmer, Jeremy Harmer",N/A,1983,https://openlibrary.org/works/OL4480543W
+The Diamond Throne (The Elenium),David Eddings,N/A,1989,https://openlibrary.org/works/OL1923074W
+The Code Breaker,"Walter Isaacson, Kathe Mazur",N/A,2021,https://openlibrary.org/works/OL24217656W
+All the Weyrs of Pern,"Anne McCaffrey, Mel Foster",N/A,1991,https://openlibrary.org/works/OL73339W
+The Essays of Elia,Charles Lamb,N/A,1823,https://openlibrary.org/works/OL44842W
+The psychology of self-esteem,Nathaniel Branden,N/A,1969,https://openlibrary.org/works/OL1835078W
+Beyond the Wand,Tom Felton,N/A,2022,https://openlibrary.org/works/OL28022286W
+The Lady with the Dog and Other Stories [9 stories],Антон Павлович Чехов,N/A,1917,https://openlibrary.org/works/OL278145W
+Introductory statistics for the behavioral sciences,"Joan Welkowitz, Barry H. Cohen, Robert B. Ewen",N/A,1971,https://openlibrary.org/works/OL58761W
+The 5th horseman,"James Patterson, Maxine Paetro",N/A,2006,https://openlibrary.org/works/OL167145W
+"""Why are all the Black kids sitting together in the cafeteria?"" and other conversations about race",Beverly Daniel Tatum,N/A,1970,https://openlibrary.org/works/OL2683670W
+School's Out Forever,James Patterson,N/A,2006,https://openlibrary.org/works/OL5337363W
+The Rebel Bride,Catherine Coulter,N/A,1979,https://openlibrary.org/works/OL14726W
+The setting sun,太宰 治,N/A,1956,https://openlibrary.org/works/OL15350754W
+Coloring Book,Goat Notebook,N/A,2020,https://openlibrary.org/works/OL30297393W
+Prodigy,Marie Lu,N/A,2012,https://openlibrary.org/works/OL16557703W
+The Maid,Nita Prose,N/A,2019,https://openlibrary.org/works/OL24554831W
+The Middle Temple Murder,Joseph Smith Fletcher,N/A,1919,https://openlibrary.org/works/OL1797756W
+In Defense of Food,Michael Pollan,N/A,2008,https://openlibrary.org/works/OL3296482W
+Lady sings the blues,"Billie Holiday, William Dufty",N/A,1956,https://openlibrary.org/works/OL5603902W
+The Master-Key to Riches,Napoleon Hill,N/A,1965,https://openlibrary.org/works/OL527463W
+The 1619 Project,"Nikole Hannah-Jones, The New York Times Company",N/A,2021,https://openlibrary.org/works/OL24340913W
+Minecraft,Max Brooks,N/A,2017,https://openlibrary.org/works/OL19710621W
+The Pleasure of Finding Things Out,"Richard Phillips Feynman, Sean Runnette, Freeman Dyson",N/A,1999,https://openlibrary.org/works/OL271751W
+Inquiry into the nature and causes of the wealth of nations,"Adam Smith, Andrew Skinner",N/A,1788,https://openlibrary.org/works/OL76825W
+"I Survived the Sinking of the Titanic, 1912","Lauren Tarshis, Georgia Ball, Lauren Haus Studio, Scott Dawson",N/A,2010,https://openlibrary.org/works/OL15492795W
+Before they are hanged,Joe Abercrombie,N/A,2007,https://openlibrary.org/works/OL8400946W
+Complications,Atul Gawande,N/A,2002,https://openlibrary.org/works/OL25651868W
+A Thief in the Night,E. W. Hornung,N/A,1905,https://openlibrary.org/works/OL250353W
+The longest ride,Nicholas Sparks,N/A,2013,https://openlibrary.org/works/OL17746362W
+Books of Blood Volume One,Clive Barker,N/A,1985,https://openlibrary.org/works/OL457864W
+The Wishsong of Shannara,Terry Brooks,N/A,1985,https://openlibrary.org/works/OL5683593W
+The night stalker,Philip Carlo,N/A,1996,https://openlibrary.org/works/OL1701098W
+The Chalice of the Gods,Rick Riordan,N/A,2023,https://openlibrary.org/works/OL34025404W
+Understanding Physics,Isaac Asimov,N/A,1966,https://openlibrary.org/works/OL46388W
+Powder and Patch,Georgette Heyer,N/A,1923,https://openlibrary.org/works/OL4092668W
+Verity,Colleen Hoover,N/A,2018,https://openlibrary.org/works/OL20068530W
+The Last Continent,Terry Pratchett,N/A,1998,https://openlibrary.org/works/OL453711W
+The shadow-line,Joseph Conrad,N/A,1917,https://openlibrary.org/works/OL38827W
+Headlong Hall,Thomas Love Peacock,N/A,1816,https://openlibrary.org/works/OL2713466W
+The Door to December,Dean Koontz,N/A,1985,https://openlibrary.org/works/OL257745W
+War Storm,Victoria Aveyard,N/A,2018,https://openlibrary.org/works/OL19740494W
+Men Without Women,Ernest Hemingway,N/A,1927,https://openlibrary.org/works/OL63067W
+Il purgatorio,Dante Alighieri,N/A,1768,https://openlibrary.org/works/OL93140W
+Mistero a Parigi,Elisabetta Dami,N/A,2008,https://openlibrary.org/works/OL15437450W
+The letters of Vita Sackville-West to Virginia Woolfe,"Vita Sackville-West, Virginia Woolf, Alison Bechdel",N/A,1984,https://openlibrary.org/works/OL1347349W
+The Italian's Inexperienced Mistress,Lynne Graham,N/A,2007,https://openlibrary.org/works/OL3773934W
+Fear Street - The Wrong Number,Robert Lawrence Stine,N/A,1990,https://openlibrary.org/works/OL72359W
+The making of the atomic bomb,Richard Rhodes,N/A,1986,https://openlibrary.org/works/OL2617750W
+Lemony Snicket,Lemony Snicket,N/A,2002,https://openlibrary.org/works/OL16031983W
+Historia Alexandri Magni,Quintus Curtius Rufus,N/A,1481,https://openlibrary.org/works/OL145025W
+Crazy Rich Asians,Kevin Kwan,N/A,2013,https://openlibrary.org/works/OL17924837W
+The Last Vampire,Christopher Pike,N/A,1994,https://openlibrary.org/works/OL1000705W
+Past tense,Lee Child,N/A,2018,https://openlibrary.org/works/OL19754749W
+Caste,"Isabel Wilkerson, Antonio Francisco Rodríguez Esteban",N/A,2020,https://openlibrary.org/works/OL20878310W
+Brunelleschi's dome,Ross King,N/A,2000,https://openlibrary.org/works/OL2984865W
+A Coffin for Dimitrios,"Eric Ambler, Mark Mazower",N/A,1939,https://openlibrary.org/works/OL3297229W
+The pyramid principle,Barbara Minto,N/A,1978,https://openlibrary.org/works/OL3012477W
+Statistical methods for the social sciences,"Alan Agresti, Barbara Finlay",N/A,1979,https://openlibrary.org/works/OL2930408W
+Great Gatsby,F. Scott Fitzgerald,N/A,1951,https://openlibrary.org/works/OL34381078W
+The Shadow of Kyoshi,"F.C. Yee, Michael Dante DiMartino",N/A,2007,https://openlibrary.org/works/OL20816519W
+Understanding Power,"Noam Chomsky, Peter R. Mitchell, John Schoeffel",N/A,2002,https://openlibrary.org/works/OL71716W
+Inheritance Games,Jennifer Lynn Barnes,N/A,2020,https://openlibrary.org/works/OL21692056W
+Goosebumps - The Haunted School,Robert Lawrence Stine,N/A,1997,https://openlibrary.org/works/OL72285W
+Tuesday,David Wiesner,N/A,1987,https://openlibrary.org/works/OL2971052W
+"The autobiography of Martin Luther King, Jr.","Martin Luther King Jr., Clayborne Carson, Intellectual Properties Management Staff",N/A,1998,https://openlibrary.org/works/OL1945953W
+The Genetic Code,Isaac Asimov,N/A,1936,https://openlibrary.org/works/OL46397W
+Queen of Shadows,Sarah J. Maas,N/A,2015,https://openlibrary.org/works/OL17718538W
+1990 census of population and housing,United States. Bureau of the Census,N/A,1992,https://openlibrary.org/works/OL33463607W
+A Dog of Flanders,Ouida,N/A,1800,https://openlibrary.org/works/OL2339940W
+Secreto,"Julie Garwood, Susan Duerden",N/A,1992,https://openlibrary.org/works/OL26937W
+Bad Blood,John Carreyrou,N/A,2018,https://openlibrary.org/works/OL17892614W
+Audition,Michael Shurtleff,N/A,1978,https://openlibrary.org/works/OL4397318W
+My Brother Sam Is Dead,"James Lincoln Collier, J Collier",N/A,1974,https://openlibrary.org/works/OL2626169W
+Shiver,Maggie Stiefvater,N/A,2008,https://openlibrary.org/works/OL11967025W
+A House for Mr. Biswas,V. S. Naipaul,N/A,1961,https://openlibrary.org/works/OL103113W
+Plague Ship,Andre Norton,N/A,1956,https://openlibrary.org/works/OL473283W
+Serpent and the Wings of Night,Carissa Broadbent,N/A,2022,https://openlibrary.org/works/OL28520883W
+Le collier de la reine,"Alexandre Dumas, Auguste Maquet",N/A,1848,https://openlibrary.org/works/OL36847W
+"Windsor Castle, an historical romance",William Harrison Ainsworth,N/A,1800,https://openlibrary.org/works/OL5201524W
+Sign of the Moon,Erin Hunter,N/A,2011,https://openlibrary.org/works/OL17455355W
+Sentiero dei nidi di ragno,Italo Calvino,N/A,1947,https://openlibrary.org/works/OL15348W
+Economics in One Lesson,Henry Hazlitt,N/A,1946,https://openlibrary.org/works/OL541970W
+There's a Wocket in my Pocket!,Dr. Seuss,N/A,1974,https://openlibrary.org/works/OL1898300W
+Tono-Bungay,H. G. Wells,N/A,1890,https://openlibrary.org/works/OL52269W
+Come as you are,"Emily Nagoski, Blanca González Villegas",N/A,2015,https://openlibrary.org/works/OL17870214W
+In Freedom's Cause,G. A. Henty,N/A,1884,https://openlibrary.org/works/OL1794681W
+The Cabin Faced West,Jean Fritz,N/A,1958,https://openlibrary.org/works/OL1931482W
+Leave the World Behind,Rumaan Alam,N/A,2020,https://openlibrary.org/works/OL20800247W
+The Diamond as Big as the Ritz,F. Scott Fitzgerald,N/A,1986,https://openlibrary.org/works/OL468539W
+"Play Ball, Amelia Bedelia","Peggy Parish, Wallace Tripp",N/A,1972,https://openlibrary.org/works/OL1933001W
+Bridget Jones,Helen Fielding,N/A,1999,https://openlibrary.org/works/OL547743W
+Nervous Conditions,Tsitsi Dangarembga,N/A,1988,https://openlibrary.org/works/OL17661158W
+9 From the Nine Worlds,Rick Riordan,N/A,2018,https://openlibrary.org/works/OL17932982W
+Nada the Lily,H. Rider Haggard,N/A,1890,https://openlibrary.org/works/OL17525W
+Shiloh,Phyllis Reynolds Naylor,N/A,1991,https://openlibrary.org/works/OL13489W
+Fear Street - The Dare,Robert Lawrence Stine,N/A,1992,https://openlibrary.org/works/OL15093962W
+Write It Right,Ambrose Bierce,N/A,1909,https://openlibrary.org/works/OL7973344W
+An Echo in the Bone,Diana Gabaldon,N/A,2009,https://openlibrary.org/works/OL14974949W
+Homecoming,Cynthia Voigt,N/A,1981,https://openlibrary.org/works/OL76797W
+Behavior in organizations,"Jerald Greenberg, Robert Baron",N/A,1993,https://openlibrary.org/works/OL1959405W
+The Whispering Skull,Jonathan Stroud,N/A,2014,https://openlibrary.org/works/OL17077412W
+The Chalk Box Kid,Clyde Robert Bulla,N/A,1897,https://openlibrary.org/works/OL8404516W
+A Dog's Purpose,W. Bruce Cameron,N/A,2010,https://openlibrary.org/works/OL15572356W
+Oathbringer,Brandon Sanderson,N/A,2017,https://openlibrary.org/works/OL17834026W
+Trauma and Recovery,Judith Lewis Herman,N/A,1901,https://openlibrary.org/works/OL2652815W
+David and Goliath,Malcolm Gladwell,N/A,2013,https://openlibrary.org/works/OL16809805W
+"Angus, Thongs and Full-Frontal Snogging",Louise Rennison,N/A,2000,https://openlibrary.org/works/OL92967W
+The Boys from Brazil,Ira Levin,N/A,1976,https://openlibrary.org/works/OL28318W
+The Journals of Sylvia Plath,"Ted Hughes, Francis McCullagh, Sylvia Plath",N/A,1982,https://openlibrary.org/works/OL1865540W
+The Crystal Shard,"R. A. Salvatore, Tim Seeley, Andrew Dabb, Val Semeiks",N/A,1988,https://openlibrary.org/works/OL516728W
+Lost in Little Bear’s Room,Else Holmelund Minarik,N/A,2002,https://openlibrary.org/works/OL4108930W
+"Many Lives, Many Masters",Brian L. Weiss,N/A,1988,https://openlibrary.org/works/OL70780W
+Harry Potter (series) 1-7,J. K. Rowling,N/A,1999,https://openlibrary.org/works/OL14981609W
+Sobre héroes y tumbas,Ernesto Sabato,N/A,1961,https://openlibrary.org/works/OL617876W
+Children of Blood and Bone,Tomi Adeyemi,N/A,2017,https://openlibrary.org/works/OL19659793W
+The diaries of Franz Kafka,Franz Kafka,N/A,1948,https://openlibrary.org/works/OL498793W
+The Prize,Daniel Yergin,N/A,1991,https://openlibrary.org/works/OL2748135W
+The Multi-orgasmic Man,"Mantak Chia, Douglas Abrams Arava, Douglas Abrams",N/A,1996,https://openlibrary.org/works/OL2856674W
+Sixth Column,Robert A. Heinlein,N/A,1657,https://openlibrary.org/works/OL59691W
+Imiginary Friend,Stephen Chbosky,N/A,2019,https://openlibrary.org/works/OL20146108W
+De medicina,"Aulus Cornelius Celsus, Celse, G. Serbat",N/A,1478,https://openlibrary.org/works/OL5225311W
+Il segreto del castello scozzese,Elisabetta Dami,N/A,2009,https://openlibrary.org/works/OL17483021W
+Annihilation,Jeff VanderMeer,N/A,2014,https://openlibrary.org/works/OL17268007W
+Fear Street Cheerleaders - The First Evil,Robert Lawrence Stine,N/A,1992,https://openlibrary.org/works/OL72269W
+The long earth,"Terry Pratchett, Stephen Baxter",N/A,2012,https://openlibrary.org/works/OL16769202W
+Everblaze,Shannon Messenger,N/A,2014,https://openlibrary.org/works/OL17080079W
+Long Live the King!,Mary Roberts Rinehart,N/A,1917,https://openlibrary.org/works/OL137385W
+"Little, Big","John Crowley, John Crowley",N/A,1981,https://openlibrary.org/works/OL482575W
+The Complete Art of Witchcraft,Sybil Leek,N/A,1971,https://openlibrary.org/works/OL4640740W
+She comes first,Ian Kerner,N/A,2004,https://openlibrary.org/works/OL5738197W
+Monster,Sanyika Shakur,N/A,1993,https://openlibrary.org/works/OL3918809W
+The Celestine Prophecy. An Experiential Guide,"James Redfield, Carol Adrienne",N/A,1995,https://openlibrary.org/works/OL53180W
+The Hawthorne Legacy,Jennifer Lynn Barnes,N/A,2021,https://openlibrary.org/works/OL24231383W
+A Bend In The Road,Nicholas Sparks,N/A,2001,https://openlibrary.org/works/OL54814W
+All American Boys,"Jason Reynolds, Brendan Kiely",N/A,2015,https://openlibrary.org/works/OL18217886W
+The Renegades of Pern,Anne McCaffrey,N/A,1989,https://openlibrary.org/works/OL73347W
+Grit,Angela Duckworth,N/A,2016,https://openlibrary.org/works/OL17361140W
+Mountains Beyond Mountains,Tracy Kidder,N/A,2003,https://openlibrary.org/works/OL98216W
+Shall we tell the President?,Jeffrey Archer,N/A,1977,https://openlibrary.org/works/OL1807092W
+What the Ladybird Heard,Julia Donaldson,N/A,2001,https://openlibrary.org/works/OL1938285W
+Midnight in Chernobyl,Adam Higginbotham,N/A,2019,https://openlibrary.org/works/OL19915768W
+Salvage the Bones,Jesmyn Ward,N/A,2011,https://openlibrary.org/works/OL16086740W
+The Only Good Indians,"Stephen Graham Jones, Shaun Taylor-Corbett, Manuel de los Reyes, Rafael Martín Coronel",N/A,2019,https://openlibrary.org/works/OL20756942W
+Caccia allo scarabeo blu,Elisabetta Dami,N/A,1900,https://openlibrary.org/works/OL16802073W
+Law dictionary,Henry Campbell Black,N/A,1933,https://openlibrary.org/works/OL1527520W
+Tschick,Wolfgang Herrndorf,N/A,2010,https://openlibrary.org/works/OL16621819W
+Man and His Symbols,Carl Gustav Jung,N/A,1964,https://openlibrary.org/works/OL95157W
+Sunset,Erin Hunter,N/A,2006,https://openlibrary.org/works/OL24217618W
+Pale Blue Dot,Carl Sagan,N/A,1994,https://openlibrary.org/works/OL2950948W
+"I Survived The Attacks of September 11, 2001","Lauren Tarshis, Rachel Fulginiti, Corey Egbert, Scott Dawson",N/A,2012,https://openlibrary.org/works/OL17104597W
+"Days of Magic, Nights of War",Clive Barker,N/A,2002,https://openlibrary.org/works/OL15834293W
+The Liars' Club,Mary Karr,N/A,1995,https://openlibrary.org/works/OL2745581W
+Amulet,Kazu Kibuishi,N/A,2012,https://openlibrary.org/works/OL17425242W
+Poppy,Avi,N/A,1995,https://openlibrary.org/works/OL465344W
+Security analysis,"Benjamin Graham, David Dodd",N/A,1934,https://openlibrary.org/works/OL823108W
+The Anthropocene Reviewed,John Green,N/A,2019,https://openlibrary.org/works/OL22425473W
+The Newcomes,William Makepeace Thackeray,N/A,1853,https://openlibrary.org/works/OL16312W
+The Witness,"Nora Roberts, Julia Whelan",N/A,2012,https://openlibrary.org/works/OL16415840W
+The Black Lyon,Jude Deveraux,N/A,1980,https://openlibrary.org/works/OL810248W
+What the body remembers,Shauna Singh Baldwin,N/A,1999,https://openlibrary.org/works/OL25910W
+The Cheater,Robert Lawrence Stine,N/A,1993,https://openlibrary.org/works/OL72375W
+Hamnet,Maggie O'Farrell,N/A,2020,https://openlibrary.org/works/OL20743965W
+The Psychopath Test,Jon Ronson,N/A,2011,https://openlibrary.org/works/OL16795887W
+The McDonaldization of Society,George Ritzer,N/A,1993,https://openlibrary.org/works/OL465449W
+The gnostic Gospels,Elaine Pagels        ,N/A,1979,https://openlibrary.org/works/OL3748808W
+The Lost City of Z,"David Grann, James Gray",N/A,2000,https://openlibrary.org/works/OL11930023W
+Vision in White,Nora Roberts,N/A,2009,https://openlibrary.org/works/OL111486W
+"Space, time and architecture",Sigfried Giedion,N/A,1941,https://openlibrary.org/works/OL1161577W
+The Great Train Robbery,Michael Crichton,N/A,1975,https://openlibrary.org/works/OL46905W
+Fantastic Beasts,J. K. Rowling,N/A,2014,https://openlibrary.org/works/OL18011053W
+Shipwreck on the Pirate Islands,"Elisabetta Dami, Manuel Manzano, David Nel·lo",N/A,2005,https://openlibrary.org/works/OL8115853W
+Dog Man,Dav Pilkey,N/A,2018,https://openlibrary.org/works/OL20085413W
+The magic toyshop,Angela Carter,N/A,1967,https://openlibrary.org/works/OL697437W
+Arrows of the Queen,Mercedes Lackey,N/A,1987,https://openlibrary.org/works/OL112556W
+La città del sole,"Tommaso Campanella, Emilio G. Estébanez, Javier Gálvez",N/A,1836,https://openlibrary.org/works/OL752625W
+Babel,R. F. Kuang,N/A,2022,https://openlibrary.org/works/OL26443093W
+It's in His Kiss,Julia Quinn,N/A,2005,https://openlibrary.org/works/OL554612W
+April Lady,Georgette Heyer,N/A,1956,https://openlibrary.org/works/OL4092682W
+The Boyfriend,Robert Lawrence Stine,N/A,1990,https://openlibrary.org/works/OL15094006W
+The Ethnic Cleansing of Palestine,"Ilan Pappé, Luis Noriega, Ilan Papeh",N/A,2006,https://openlibrary.org/works/OL8324629W
+The First Man in Rome,Colleen McCullough,N/A,1990,https://openlibrary.org/works/OL1882554W
+The wife between us,Greer Hendricks,N/A,2017,https://openlibrary.org/works/OL19735648W
+Εὐθύφρων,Πλάτων,N/A,1880,https://openlibrary.org/works/OL51781W
+An Investigation of the Laws of Thought (Barnes & Noble),George Boole,N/A,1854,https://openlibrary.org/works/OL2630376W
+Tithe,Holly Black,N/A,2002,https://openlibrary.org/works/OL5833930W
+It Starts with Us,Colleen Hoover,N/A,2022,https://openlibrary.org/works/OL27733867W
+Hondo,Louis L'Amour,N/A,1953,https://openlibrary.org/works/OL50908W
+Bone,Jeff Smith,N/A,1995,https://openlibrary.org/works/OL708284W
+The Greatest Show on Earth,Richard Dawkins,N/A,2009,https://openlibrary.org/works/OL1966487W
+The Kingdom of Fantasy,"Elisabetta Dami, David Nel·lo, Larry Keys, Titi Plumederat, Koldo Biguri",N/A,2005,https://openlibrary.org/works/OL15493152W
+Diary of a provincial lady,"E. M. Delafield, Jilly Cooper, Edmée Elizabeth Dashwood",N/A,1930,https://openlibrary.org/works/OL4458124W
+Hackers,Steven Levy,N/A,1984,https://openlibrary.org/works/OL804638W
+The Young Elites,Marie Lu,N/A,2014,https://openlibrary.org/works/OL17082066W
+"Heartstopper, Volume 1",Alice Oseman,N/A,2018,https://openlibrary.org/works/OL20354498W
+The Road Less Traveled,M. Scott Peck,N/A,1978,https://openlibrary.org/works/OL2868914W
+A Flicker in the Dark,Stacy Willingham,N/A,2022,https://openlibrary.org/works/OL24592608W
+The ranch,Danielle Steel,N/A,1992,https://openlibrary.org/works/OL10614077W
+Rodin,"Auguste Rodin, Catherine Lampert, Antoinette Romain",N/A,1924,https://openlibrary.org/works/OL534146W
+The Girlfriend,Robert Lawrence Stine,N/A,1991,https://openlibrary.org/works/OL15094808W
+The king of the castle,"Victoria Holt, Virginia Holt, Phil Carr",N/A,1967,https://openlibrary.org/works/OL3931519W
+To Be a Slave (Plus),"Julius Lester, Julius Lester",N/A,1968,https://openlibrary.org/works/OL1814435W
+Electra,Sophocles,N/A,1588,https://openlibrary.org/works/OL43858W
+The Bayonet,United States Army,N/A,1942,https://openlibrary.org/works/OL17320543W
+The Bean Trees,Barbara Kingsolver,N/A,1988,https://openlibrary.org/works/OL1846881W
+The Greek Tycoon's Pregnant Wife,Anne Mather,N/A,2007,https://openlibrary.org/works/OL3771088W
+The Enemy (The Enemy #1),Charles Higson,N/A,2009,https://openlibrary.org/works/OL14935845W
+Babylon's Ashes (The Expanse),James S. A. Corey,N/A,2016,https://openlibrary.org/works/OL19099155W
+It's Not Summer Without You,Jenny Han,N/A,2010,https://openlibrary.org/works/OL15640090W
+The Way I Used To Be,Amber Smith,N/A,2016,https://openlibrary.org/works/OL17356805W
+The Apartment,Danielle Steel,N/A,2016,https://openlibrary.org/works/OL17344325W
+The Everything Store,"Brad Stone, Brad Stone",N/A,2013,https://openlibrary.org/works/OL16808249W
+The Sun and the Star,"Rick Riordan, Mark Oshiro",N/A,2023,https://openlibrary.org/works/OL28868481W
+The wimpy kid movie diary,Jeff Kinney,N/A,2010,https://openlibrary.org/works/OL15110519W
+The Pigeon finds a hot dog!,Mo Willems,N/A,2004,https://openlibrary.org/works/OL5759980W
+The Innovators,Walter Isaacson,N/A,2014,https://openlibrary.org/works/OL17074268W
+Revenge of the Living Dummy,Robert Lawrence Stine,N/A,2008,https://openlibrary.org/works/OL16660324W
+Red Queen,Victoria Aveyard,N/A,2015,https://openlibrary.org/works/OL19761522W
+The Invention of Hugo Cabret,Brian Selznick,N/A,1920,https://openlibrary.org/works/OL50231W
+La città segreta,Elisabetta Dami,N/A,2006,https://openlibrary.org/works/OL16182868W
+Expert testimony before the Indian Claims Commission,United States. Indian Claims Commission,N/A,1958,https://openlibrary.org/works/OL31775436W
+Team of Rivals,Doris Kearns Goodwin,N/A,2003,https://openlibrary.org/works/OL1856010W
+BRAIDING SWEETGRASS,"Robin Wall Kimmerer, David Muñoz Mateos",N/A,2013,https://openlibrary.org/works/OL16819897W
+Seveneves,Neal Stephenson,N/A,2015,https://openlibrary.org/works/OL17829905W
+"No, David!","David Shannon, Teresa Mlawer",N/A,1998,https://openlibrary.org/works/OL547372W
+Maybe You Should Talk to Someone,Lori Gottlieb,N/A,2019,https://openlibrary.org/works/OL19791590W
+Jumanji,Chris Van Allsburg,N/A,1981,https://openlibrary.org/works/OL3743769W
+Bread and jam for Frances,Russell Hoban,N/A,1964,https://openlibrary.org/works/OL74290W
+Codependent No More,Melody Beattie,N/A,1986,https://openlibrary.org/works/OL45922W
+The rambler,Samuel Johnson,N/A,1750,https://openlibrary.org/works/OL14862914W
+Artemis Fowl. The Lost Colony,Eoin Colfer,N/A,2006,https://openlibrary.org/works/OL5725977W
+Killing Pablo,Mark Bowden,N/A,2001,https://openlibrary.org/works/OL491853W
+First Test (Protector of the Small #1),Tamora Pierce,N/A,1999,https://openlibrary.org/works/OL29276W
+The art of being human,"Richard Paul Janaro, Thelma C. Altshuler",N/A,1979,https://openlibrary.org/works/OL3242249W
+The flight of the shadow,George MacDonald,N/A,1891,https://openlibrary.org/works/OL15408W
+The millionaire mind,Thomas J. Stanley,N/A,2000,https://openlibrary.org/works/OL15844085W
+A history of western philosophy,Bertrand Russell,N/A,1945,https://openlibrary.org/works/OL1088357W
+The Lion's Lady,Julie Garwood,N/A,1988,https://openlibrary.org/works/OL26949W
+"Laws, etc. (Session laws : 1796-01)",New York (State),N/A,1782,https://openlibrary.org/works/OL929211W
+Health and personal social services,Rand McNally,N/A,1986,https://openlibrary.org/works/OL14903347W
+Geology,"Stanley Chernicoff, Ramesh Venkatakrishnan, Donna Whitney",N/A,1957,https://openlibrary.org/works/OL530928W
+Houghton Mifflin the Nation's Choice,Houghton Mifflin Company Staff,N/A,2000,https://openlibrary.org/works/OL27468135W
+The Glass Hotel,Emily St. John Mandel,N/A,2020,https://openlibrary.org/works/OL20656802W
+Twentieth Wife,Indu Sundaresan,N/A,2002,https://openlibrary.org/works/OL6048818W
+The Family Upstairs,Lisa Jewell,N/A,2019,https://openlibrary.org/works/OL20416046W
+"Beautiful World, Where Are You","Sally Rooney, Octavi Gil Pujol",N/A,2021,https://openlibrary.org/works/OL24151602W
+Long Shadows,Erin Hunter,N/A,2008,https://openlibrary.org/works/OL5714278W
+A Promised Land,"Barack Obama, Francisco José Ramos Mena, Efrén del Valle Peñamil, Marcos Pérez Sánchez, Carmen Mercedes Cáceres, Andrés Barba Muñiz",N/A,2020,https://openlibrary.org/works/OL22235242W
+Proserpine & Midas,Mary Shelley,N/A,1922,https://openlibrary.org/works/OL450122W
+Pax,Sara Pennypacker,N/A,2016,https://openlibrary.org/works/OL17364508W
+The Bobbsey Twins,Laura Lee Hope,N/A,1904,https://openlibrary.org/works/OL4072567W
+Lapvona,Ottessa Moshfegh,N/A,2022,https://openlibrary.org/works/OL25808023W
+Battle royale,"Kōshun Takami, Masayuki Taguchi, Koushun Takami, Kashoun Takami, KOUSHUM TAKAMI, Koushum Takami",N/A,1999,https://openlibrary.org/works/OL8897717W
+Asylums,Erving Goffman,N/A,1961,https://openlibrary.org/works/OL3282032W
+Hollywood Babylon,Kenneth Anger,N/A,1959,https://openlibrary.org/works/OL5360006W
+Little Wizard stories of Oz,L. Frank Baum,N/A,1914,https://openlibrary.org/works/OL18394W
+Guide des mouvements de musculation,Frédéric Delavier,N/A,2001,https://openlibrary.org/works/OL5829125W
+And to think that I saw it on Mulberry Street,Dr. Seuss,N/A,1937,https://openlibrary.org/works/OL1898303W
+Breath of scandal,Sandra Brown,N/A,1991,https://openlibrary.org/works/OL167304W
+The Hero with a Thousand Faces,Joseph Campbell,N/A,1968,https://openlibrary.org/works/OL4888641W
+El Zorro,Isabel Allende,N/A,2005,https://openlibrary.org/works/OL1905366W
+Midnight Bayou,Nora Roberts,N/A,2001,https://openlibrary.org/works/OL111619W
+The four feathers,A. E. W. Mason,N/A,1902,https://openlibrary.org/works/OL532451W
+The Lincoln Lawyer (Mickey Haller #1),Michael Connelly,N/A,2001,https://openlibrary.org/works/OL111746W
+The secret of the old clock,Mildred Augustine Wirt Benson,N/A,1930,https://openlibrary.org/works/OL39840W
+The 50th law,"Robert Greene, 50 Cent, Cristina Pizarro Mato, 50 Cent Staff",N/A,2009,https://openlibrary.org/works/OL1968358W
+Arabian medicine,Edward Granville Browne,N/A,1899,https://openlibrary.org/works/OL94947W
+Death and the king's horseman,Wole Soyinka,N/A,1975,https://openlibrary.org/works/OL15125398W
+Snow Treasure,Marie McSwigan,N/A,1942,https://openlibrary.org/works/OL5844479W
+Uncle Bernac,Arthur Conan Doyle,N/A,1897,https://openlibrary.org/works/OL262502W
+The Cat Who Could Read Backwards,Lilian Jackson Braun,N/A,1966,https://openlibrary.org/works/OL457916W
+The Power,Rhonda Byrne,N/A,2010,https://openlibrary.org/works/OL15344147W
+Mistero dietro le quinte,Elisabetta Dami,N/A,2011,https://openlibrary.org/works/OL17475161W
+Think Like a Freak,"Steven D. Levitt, Stephen J. Dubner",N/A,2014,https://openlibrary.org/works/OL17078346W
+The Five Red Herrings,Dorothy L. Sayers,N/A,1931,https://openlibrary.org/works/OL2234843W
+The hidden staircase,Mildred Augustine Wirt Benson,N/A,1930,https://openlibrary.org/works/OL39827W
+The Best Friend,Robert Lawrence Stine,N/A,1992,https://openlibrary.org/works/OL15093856W
+The Last Thing He Told Me,Laura Dave,N/A,2021,https://openlibrary.org/works/OL24161797W
+Trial for Murder,Charles Dickens,N/A,2008,https://openlibrary.org/works/OL21899442W
+Night of the Living Dummy III,Robert Lawrence Stine,N/A,1995,https://openlibrary.org/works/OL15094220W
+As Sure as the Dawn,"Francine Rivers, Francine Rivers",N/A,1995,https://openlibrary.org/works/OL15181842W
+The White Tiger,Aravind Adiga,N/A,2008,https://openlibrary.org/works/OL21502115W
+The People in the Trees,Hanya Yanagihara,N/A,2013,https://openlibrary.org/works/OL19111131W
+Theory of games and economic behavior,"John Von Neumann, Oskar Morgenstern",N/A,1944,https://openlibrary.org/works/OL1204974W
+Computer science,"J. Glenn Brookshear, Brookshear",N/A,1985,https://openlibrary.org/works/OL3275955W
+One L,Scott Turow,N/A,1977,https://openlibrary.org/works/OL26908W
+Stamped from the Beginning,Ibram X. Kendi,N/A,2016,https://openlibrary.org/works/OL17592859W
+The Secret of the Nagas,Amish Tripathi,N/A,2011,https://openlibrary.org/works/OL16091708W
+The sky-liners,Louis L'Amour,N/A,1967,https://openlibrary.org/works/OL51078W
+The book of Thoth,Aleister Crowley,N/A,1944,https://openlibrary.org/works/OL136330W
+Dog Man,Dav Pilkey,N/A,2019,https://openlibrary.org/works/OL20573281W
+The Theory of the Leisure Class,Thorstein Veblen,N/A,1899,https://openlibrary.org/works/OL1868441W
+The essential Rumi,"Rumi (Jalāl ad-Dīn Muḥammad Balkhī), JalaÌ„l al-DiÌ„n RuÌ„miÌ„, Jalal ad-Din Muhammad Rumi",N/A,1995,https://openlibrary.org/works/OL18987W
+The Man from St. Petersburg,Ken Follett,N/A,1982,https://openlibrary.org/works/OL15649851W
+The wedding,Nicholas Sparks,N/A,2003,https://openlibrary.org/works/OL54810W
+The Magic School Bus,Joanna Cole,N/A,1990,https://openlibrary.org/works/OL83103W
+The Schoolboy's Story,Charles Dickens,N/A,2014,https://openlibrary.org/works/OL20343103W
+My life and work,"Ford, Henry, Henry Ford, Samuel Crowther, Henry, Ford, Ford Henry 1863-1947, Mrs Henry Ford, E. Kalita, Ford, Henry, Crowther, Samuel, Henry Henry Ford, Samuel Crowther",N/A,1922,https://openlibrary.org/works/OL4418043W
+The false prince,Jennifer A. Nielsen,N/A,2012,https://openlibrary.org/works/OL15932756W
+"How I survived bullies, broccoli and Snake Hill","James Patterson, Chris Tebbetts",N/A,2012,https://openlibrary.org/works/OL17050972W
+Stepping heavenward,Elizabeth Prentiss,N/A,1869,https://openlibrary.org/works/OL811123W
+World mythology,Donna Rosenberg,N/A,1986,https://openlibrary.org/works/OL1981909W
+Black's Law Dictionary,Bryan A. Garner,N/A,1990,https://openlibrary.org/works/OL811296W
+Matisse,Henri Matisse,N/A,1943,https://openlibrary.org/works/OL1227093W
+"The deluge: an historical novel of Poland, Sweden and Russia","Henryk Sienkiewicz, Jeremiah Curtin",N/A,1888,https://openlibrary.org/works/OL503366W
+American Odyssey,Gary B. Nash,N/A,1991,https://openlibrary.org/works/OL156948W
+The Darkest Minds,"Alexandra Bracken, Amy McFadden, Montserrat Triviño Gonzalez",N/A,2012,https://openlibrary.org/works/OL16591835W
+Dostoyevsky. Notes From Underground / White Nights / The Dream of a Ridiculous Man / Selections from The House of the Dead,Фёдор Михайлович Достоевский,N/A,1961,https://openlibrary.org/works/OL166934W
+The Man in Lower Ten,Mary Roberts Rinehart,N/A,1909,https://openlibrary.org/works/OL137395W
+The Immortals of Meluha,Amish Tripathi,N/A,2010,https://openlibrary.org/works/OL15914981W
+The Four Agreements,Don Miguel Ruiz,N/A,1997,https://openlibrary.org/works/OL27203W
+When He Was Wicked,Julia Quinn,N/A,2004,https://openlibrary.org/works/OL554621W
+Drácula,Bram Stoker,N/A,2017,https://openlibrary.org/works/OL29743739W
+Darkwater; voices from within the veil,W. E. B. Du Bois,N/A,1920,https://openlibrary.org/works/OL28571W
+The Velvet Promise,Jude Deveraux,N/A,1981,https://openlibrary.org/works/OL810184W
+Motel of the mysteries,David Macaulay,N/A,1979,https://openlibrary.org/works/OL74030W
+The Kill Artist,Daniel Silva,N/A,1996,https://openlibrary.org/works/OL1814743W
+Niezwyciężony,Stanisław Lem,N/A,1967,https://openlibrary.org/works/OL109498W
+The Idiot,Elif Batuman,N/A,2017,https://openlibrary.org/works/OL17771503W
+House Across the Lake,Todd Ritter,N/A,2022,https://openlibrary.org/works/OL25809537W
+The Sellout,Paul Beatty,N/A,2015,https://openlibrary.org/works/OL17616758W
+The Authoritative Calvin and Hobbes,Bill Watterson,N/A,1988,https://openlibrary.org/works/OL3004222W
+Dance of the Gods,Nora Roberts,N/A,2006,https://openlibrary.org/works/OL111623W
+The Clue of the Broken Locket,Mildred Augustine Wirt Benson,N/A,1963,https://openlibrary.org/works/OL15861909W
+Het Diner,Herman Koch,N/A,2009,https://openlibrary.org/works/OL2486917W
+The Sleepwalker,Robert Lawrence Stine,N/A,1990,https://openlibrary.org/works/OL72336W
+The Street of Seven Stars,Mary Roberts Rinehart,N/A,1914,https://openlibrary.org/works/OL137393W
+Elegiae,"Sextus Propertius, Albius Tibullus, Georg Luck",N/A,1780,https://openlibrary.org/works/OL1313851W
+Billions and billions,Carl Sagan,N/A,1997,https://openlibrary.org/works/OL2950946W
+The nature and properties of soils,"Nyle C. Brady, Ray R. Weil",N/A,1974,https://openlibrary.org/works/OL1853654W
+Rime,Francesco Petrarca,N/A,1475,https://openlibrary.org/works/OL15469822W
+The People of Sparks (Book of Ember #2),Jeanne DuPrau,N/A,2004,https://openlibrary.org/works/OL4132757W
+The last song,Nicholas Sparks,N/A,2009,https://openlibrary.org/works/OL14873874W
+Style,"Joseph M. Williams, Joseph Bizup, Gregory G. Colomb",N/A,1981,https://openlibrary.org/works/OL12199W
+The seat of the soul,Gary Zukav,N/A,1989,https://openlibrary.org/works/OL788830W
+The Worst Witch (The Worst Witch #1),Jill Murphy,N/A,1974,https://openlibrary.org/works/OL496118W
+The Tailor of Gloucester,"Beatrix Potter, H.Y. Xiao PhD, H y Xiao Phd",N/A,1903,https://openlibrary.org/works/OL108770W
+Dark River,Erin Hunter,N/A,2007,https://openlibrary.org/works/OL5714308W
+House of Earth and Blood,Sarah J. Maas,N/A,2019,https://openlibrary.org/works/OL20650912W
+"Boy, the Mole, the Fox and the Horse",Charlie Mackesy,N/A,2019,https://openlibrary.org/works/OL21208765W
+The Mysterious Benedict Society (The Mysterious Benedict Society #1),Trenton Lee Stewart,N/A,2007,https://openlibrary.org/works/OL5848457W
+Rework,"Jason Fried, David Heinemeier Hansson",N/A,2010,https://openlibrary.org/works/OL15168112W
+How to Do Nothing,"Jenny Odell, Rebecca Gibel",N/A,2019,https://openlibrary.org/works/OL20078135W
+The Midnight Gang,"David Walliams, Tony Ross, Mared Llwyd",N/A,2016,https://openlibrary.org/works/OL17638522W
+Twelve against the gods,William Bolitho,N/A,1929,https://openlibrary.org/works/OL5917484W
+Final Gambit,"Jennifer Lynn Barnes, Jennifer Barnes",N/A,2022,https://openlibrary.org/works/OL26515194W
+The Wild Robot Escapes,Peter Brown,N/A,2016,https://openlibrary.org/works/OL19547201W
+"Works (Hitch Hiker's Guide to the Galaxy / Restaurant at the End of the Universe / Life, the Universe and Everything / So Long, and Thanks for All the Fish / Mostly Harmless / Young Zaphod Plays it Safe)",Douglas Adams,N/A,1996,https://openlibrary.org/works/OL2163706W
+Anxious People,Fredrik Backman,N/A,2020,https://openlibrary.org/works/OL20793817W
+Journeys out of the body,Robert A. Monroe,N/A,1971,https://openlibrary.org/works/OL3843339W
+The Secret Bedroom,Robert Lawrence Stine,N/A,1991,https://openlibrary.org/works/OL15094332W
+Les Bijoux de la Castafiore,Hergé,N/A,1939,https://openlibrary.org/works/OL151055W
+Three Ghost Stories,Charles Dickens,N/A,2008,https://openlibrary.org/works/OL26643330W
+P.S. I Still Love You,Jenny Han,N/A,2000,https://openlibrary.org/works/OL17356811W
+Gifted hands,"Ben Carson, Cecil Murphey, Benjamin S. Carson Sr.",N/A,1990,https://openlibrary.org/works/OL1933963W
+The Indispensable Calvin and Hobbes,Bill Watterson,N/A,1992,https://openlibrary.org/works/OL3004215W
+Ikigai,"Héctor García, Francesc Miralles",N/A,2016,https://openlibrary.org/works/OL19714233W
+Three Men in a Boat,Jerome Klapka Jerome,N/A,1979,https://openlibrary.org/works/OL21370266W
+Chantaje Emocional/Emotional Blackmail,"Susan Forward, Donna Frazier",N/A,1996,https://openlibrary.org/works/OL1929398W
+Why Nations Fail,"Daron Acemoglu, James A. Robinson",N/A,2012,https://openlibrary.org/works/OL16568759W
+I Heard You Paint Houses,Charles Brandt,N/A,2004,https://openlibrary.org/works/OL4979625W
+Ship of Magic,Robin Hobb,N/A,1998,https://openlibrary.org/works/OL2707209W
+Attack of the Deranged Mutant Killer Monster Snow Goons,Bill Watterson,N/A,1992,https://openlibrary.org/works/OL3004212W
+True to the Game,Teri Woods,N/A,1994,https://openlibrary.org/works/OL8135777W
+Secrets of the Baby Whisperer,"Tracy Hogg, Melinda Blau",N/A,2001,https://openlibrary.org/works/OL7917130W
+Hymns and spiritual songs,Isaac Watts,N/A,1707,https://openlibrary.org/works/OL15323013W
+Scattered,Gabor Maté,N/A,1999,https://openlibrary.org/works/OL8201268W
+Swiss Family Robinson,Johann David Wyss,N/A,1924,https://openlibrary.org/works/OL27587809W
+The Heroes of Olympus Hardcover Boxed Set,"Rick Riordan, John Rocco",N/A,2014,https://openlibrary.org/works/OL24319020W
+Hernani,Victor Hugo,N/A,1830,https://openlibrary.org/works/OL1064116W
+The Reluctant Husband,Lynne Graham,N/A,1998,https://openlibrary.org/works/OL7990767W
+The Hired Girl,Laura Amy Schlitz,N/A,2015,https://openlibrary.org/works/OL18020192W
+Dear Evan Hansen,Val Emmich,N/A,2018,https://openlibrary.org/works/OL19765160W
+The Poppy War,"R. F. Kuang, Emily Woo Zeller",N/A,2018,https://openlibrary.org/works/OL19351054W
+The language of clothes,Alison Lurie,N/A,1981,https://openlibrary.org/works/OL102914W
+Art & fear,"David Bayles, Ted Orland",N/A,1993,https://openlibrary.org/works/OL3936078W
+The Apprentice's Quest,Erin Hunter,N/A,2016,https://openlibrary.org/works/OL19665519W
+The web application hacker's handbook,"Dafydd Stuttard, Dafydd Stuttard",N/A,2007,https://openlibrary.org/works/OL13814659W
+The Basketball diaries,Jim Carroll,N/A,1978,https://openlibrary.org/works/OL1805823W
+Psychology,"Charles G. Morris, Albert A. Maisto",N/A,1973,https://openlibrary.org/works/OL1816886W
+The Kill Order,James Dashner,N/A,2012,https://openlibrary.org/works/OL16671713W
+The Signal and the Noise,Nate Silver,N/A,2012,https://openlibrary.org/works/OL16700318W
+Wasted,Marya Hornbacher,N/A,1998,https://openlibrary.org/works/OL2679254W
+Cheaper by the Dozen (Cheaper by the Dozen #1),"Frank B. Gilbreth, Jr., Ernestine Gilbreth Carey",N/A,1948,https://openlibrary.org/works/OL3926217W
+I Wonder Why Spiders Spin Webs and Other Questions About Creepy-crawlies (I Wonder Why),"Amanda O'Neill, Amanda O'Neil, World Book Encyclopedia, Amanda O'Neill, Amanda O'Neill",N/A,1995,https://openlibrary.org/works/OL1962829W
+The One and Only Bob,Katherine Applegate,N/A,2020,https://openlibrary.org/works/OL20808748W
+The Ruins,Scott Smith,N/A,2005,https://openlibrary.org/works/OL6218186W
+The Cartel,Ashley & JaQuavis,N/A,2009,https://openlibrary.org/works/OL13754370W
+走ることについて語るときに僕の語ること,村上春樹,N/A,2006,https://openlibrary.org/works/OL2625422W
+The Contaxis Baby,Lynne Graham,N/A,2002,https://openlibrary.org/works/OL3773896W
+The Archetypes and the Collective Unconscious,Carl Gustav Jung,N/A,1959,https://openlibrary.org/works/OL261714W
+Lives on the boundary,"Mike Rose, Mike Rose",N/A,1989,https://openlibrary.org/works/OL2772036W
+Hunted Down,Charles Dickens,N/A,1996,https://openlibrary.org/works/OL14869133W
+Zero to One,"Peter A. Thiel, Blake Masters",N/A,2001,https://openlibrary.org/works/OL17078706W
+"The History of Pendennis, His Fortunes and Misfortunes, His Friends and His Greatest Enemy",William Makepeace Thackeray,N/A,1848,https://openlibrary.org/works/OL16277W
+Expecting the Playboy's Heir,Penny Jordan,N/A,2005,https://openlibrary.org/works/OL3759292W
+The Emperor's Soul,Brandon Sanderson,N/A,2012,https://openlibrary.org/works/OL19960448W
+A Deepness in the Sky (Zones of Thought),Vernor Vinge,N/A,1999,https://openlibrary.org/works/OL1975705W
+Child development,John W. Santrock,N/A,1989,https://openlibrary.org/works/OL79240W
+"Nature, Man,& Woman",Alan Watts,N/A,1958,https://openlibrary.org/works/OL266156W
+Darkness of Dragons,Tui T. Sutherland,N/A,2015,https://openlibrary.org/works/OL17834480W
+Die Therapie,Sebastian Fitzek,N/A,2006,https://openlibrary.org/works/OL12049027W
+Eclipse,Erin Hunter,N/A,2008,https://openlibrary.org/works/OL14906959W
+Carrion comfort,Dan Simmons,N/A,1989,https://openlibrary.org/works/OL1963277W
+The Prom Queen,Robert Lawrence Stine,N/A,1992,https://openlibrary.org/works/OL15094648W
+Gone-Away Lake (Gone-Away Lake #1),"Elizabeth Enright, Beth Krush, Joe Krush, Colleen Delany (narrator)",N/A,1957,https://openlibrary.org/works/OL500561W
+YPromesa De Felicidad,Betty Neels,N/A,1979,https://openlibrary.org/works/OL3457845W
+The Key to Midnight,Dean Koontz,N/A,1979,https://openlibrary.org/works/OL497089W
+The Nonesuch,Georgette Heyer,N/A,1962,https://openlibrary.org/works/OL4092578W
+The Girl with Green Eyes,Betty Neels,N/A,1990,https://openlibrary.org/works/OL3458001W
+The Stepsister,Robert Lawrence Stine,N/A,1990,https://openlibrary.org/works/OL72340W
+Cadáver exquisito,Agustina Bazterrica,N/A,2015,https://openlibrary.org/works/OL17864836W
+The Psychology of Selling,Brian Tracy,N/A,1986,https://openlibrary.org/works/OL2392356W
+What Do You Care What Other People Think?,"Richard Phillips Feynman, Ralph Leighton",N/A,1988,https://openlibrary.org/works/OL514628W
+The Spanish Billionaire's Pregnant Wife,Lynne Graham,N/A,2009,https://openlibrary.org/works/OL3773972W
+Mistborn,Brandon Sanderson,N/A,2001,https://openlibrary.org/works/OL16044142W
+Tar Baby,Toni Morrison,N/A,1981,https://openlibrary.org/works/OL50557W
+Lives of Girls and Women,Alice Munro,N/A,1971,https://openlibrary.org/works/OL931688W
+Hudibras,Samuel Butler,N/A,1662,https://openlibrary.org/works/OL3159983W
+The Legacy,R. A. Salvatore,N/A,1992,https://openlibrary.org/works/OL516689W
+The Handmaid's Tale--The Graphic Novel,Renee Nault,N/A,2019,https://openlibrary.org/works/OL21354339W
+Secrets of Closing the Sale,"Zig Ziglar, Kevin Harrington",N/A,1984,https://openlibrary.org/works/OL1923962W
+Khozi͡ain i rabotnik,"Tolstoy, Leo, graf, 1828-1910",N/A,1895,https://openlibrary.org/works/OL15236124W
+The Lost Continent,C. J. Cutcliffe Hyne,N/A,1972,https://openlibrary.org/works/OL117047W
+"Change your brain, change your life","Daniel G. Amen, Daniel G Amen, Daniel G. Amen M.D., Daniel G. Md Amen, Dr Daniel G Amen MD",N/A,1998,https://openlibrary.org/works/OL13187W
+Before I Go to Sleep,S. J. Watson,N/A,2011,https://openlibrary.org/works/OL19633909W
+Streams of Silver,R. A. Salvatore,N/A,1989,https://openlibrary.org/works/OL516773W
+Crazy like us,Ethan Watters,N/A,2010,https://openlibrary.org/works/OL8311607W
+Developing the Leader Within You,John C. Maxwell,N/A,1993,https://openlibrary.org/works/OL28134W
+Borgias,Alexandre Dumas,N/A,1922,https://openlibrary.org/works/OL36278W
+Persepolis. The Story of a Childhood,Marjane Satrapi,N/A,2003,https://openlibrary.org/works/OL20715162W
+Greenlights,Matthew McConaughey,N/A,2020,https://openlibrary.org/works/OL21911019W
+Freedom Is a Constant Struggle,"Angela Y. Davis, Frank Barat, Coleen Marlo",N/A,2015,https://openlibrary.org/works/OL17794034W
+The ship of Ishtar,"A. Merritt, Amelia Pérez de Villar Herranz",N/A,1924,https://openlibrary.org/works/OL4104766W
+Leopard in the Snow,Anne Mather,N/A,1974,https://openlibrary.org/works/OL3771279W
+Longman Reading World,Wendy Body,N/A,1987,https://openlibrary.org/works/OL224573W
+Armada,Ernest Cline,N/A,2015,https://openlibrary.org/works/OL17343072W
+The Magic of Reality,"Richard Dawkins, Dave McKean",N/A,2001,https://openlibrary.org/works/OL16116943W
+"Eats, Shoots & Leaves",Lynne Truss,N/A,2003,https://openlibrary.org/works/OL2793678W
+Seeing Like a State,James C. Scott,N/A,1998,https://openlibrary.org/works/OL26241985W
+Cadillac desert,Marc Reisner,N/A,1986,https://openlibrary.org/works/OL4037585W
+Lodestar,Shannon Messenger,N/A,2016,https://openlibrary.org/works/OL17714888W
+Pete the Cat,James Dean,N/A,2015,https://openlibrary.org/works/OL21803737W
+Tale of Mr. Jeremy Fisher,Beatrix Potter,N/A,1906,https://openlibrary.org/works/OL11553363W
+Dark Prince,Christine Feehan,N/A,1999,https://openlibrary.org/works/OL5683845W
+The 4 Hour Workweek,"Timothy Ferriss, Timothy Ferriss",N/A,2007,https://openlibrary.org/works/OL17060108W
+Main-travelled roads,"Hamlin Garland, Jonathan Senchyne, Brianne Jaquette",N/A,1891,https://openlibrary.org/works/OL1795445W
+Thirteen days,Robert F. Kennedy,N/A,1969,https://openlibrary.org/works/OL2011065W
+Il segreto delle fate degli oceani,Elisabetta Dami,N/A,2015,https://openlibrary.org/works/OL17604499W
+The Sheep-Pig,"Dick King-Smith, Georgia Abernethy",N/A,1983,https://openlibrary.org/works/OL14993W
+Under the Whispering Door,T. J. Klune,N/A,2021,https://openlibrary.org/works/OL20862021W
+Ancillary Justice,Ann Leckie,N/A,2013,https://openlibrary.org/works/OL17062644W
+Camp Half-Blood Confidential,Rick Riordan,N/A,2017,https://openlibrary.org/works/OL20218895W
+The Clique,Lisi Harrison,N/A,2004,https://openlibrary.org/works/OL5711694W
+The Admirable Crichton,J. M. Barrie,N/A,1900,https://openlibrary.org/works/OL461990W
+Vampire Chronicles (Interview with the Vampire / Queen of the Damned / Vampire Lestat),Anne Rice,N/A,1989,https://openlibrary.org/works/OL77812W
+Just so stories for little children. Stalky & Co.,Rudyard Kipling,N/A,1902,https://openlibrary.org/works/OL19903W
+The Housemaid,Freida McFadden,N/A,2022,https://openlibrary.org/works/OL27729743W
+Cognitive Psychology,Kathleen M. Galotti,N/A,1994,https://openlibrary.org/works/OL1909049W
+The Demigod Files,Rick Riordan,N/A,2009,https://openlibrary.org/works/OL14955039W
+Daughter of the Moon Goddess,Sue Lynn Tan,N/A,2022,https://openlibrary.org/works/OL25798494W
+The Black Prism,Brent Weeks,N/A,2010,https://openlibrary.org/works/OL15317896W
+Anna and the French Kiss,Stephanie Perkins,N/A,2010,https://openlibrary.org/works/OL15111473W
+The Happiest Man on Earth,Eddie Jaku,N/A,2020,https://openlibrary.org/works/OL24345557W
+Burnout,"Emily Nagoski, Amelia Nagoski",N/A,2019,https://openlibrary.org/works/OL20163365W
+The Three Theban Plays,"Sophocles, Robert Fagles",N/A,1956,https://openlibrary.org/works/OL43844W
+I'll Be Gone in the Dark,Michelle McNamara,N/A,2018,https://openlibrary.org/works/OL18195597W
+The Hobbit,"Charles Dixon, Sean Deming, J.R.R. Tolkien",N/A,1990,https://openlibrary.org/works/OL219602W
+Shatter Me,Tahereh Mafi,N/A,2011,https://openlibrary.org/works/OL16014245W
+"Coningsby, or, The new generation",Benjamin Disraeli,N/A,1844,https://openlibrary.org/works/OL1104323W
+The Happiness Hypothesis,Jonathan Haidt,N/A,2005,https://openlibrary.org/works/OL5829273W
+Titan,Ron Chernow,N/A,1998,https://openlibrary.org/works/OL2665190W
+Trollkarlens hatt,Tove Jansson,N/A,1950,https://openlibrary.org/works/OL2195990W
+The Exploits of Brigadier Gerard,Arthur Conan Doyle,N/A,1896,https://openlibrary.org/works/OL262581W
+Capitalism and freedom,Milton Friedman,N/A,1962,https://openlibrary.org/works/OL2747782W
+The Phoenix Project,"Gene Kim, Kevin Behr, George Spafford, Gene Kim",N/A,2013,https://openlibrary.org/works/OL16806686W
+The Bridge Kingdom,Danielle L. Jensen,N/A,2019,https://openlibrary.org/works/OL20908682W
+The Lincoln Highway,Amor Towles,N/A,2021,https://openlibrary.org/works/OL24205227W
+Killing for Company,Brian Masters,N/A,1985,https://openlibrary.org/works/OL3636266W
+The Mysterious Rider,Zane Grey,N/A,1921,https://openlibrary.org/works/OL485697W
+Rhythm of War,Brandon Sanderson,N/A,2011,https://openlibrary.org/works/OL20842226W
+Muhammad,Martin Lings,N/A,1983,https://openlibrary.org/works/OL977930W
+The care & keeping of you,Valorie Lee Schaefer,N/A,1998,https://openlibrary.org/works/OL1906234W
+"Mog, the forgetful cat",Judith Kerr,N/A,1970,https://openlibrary.org/works/OL1742410W
+Kingdom of the Wicked,Kerri Maniscalco,N/A,2020,https://openlibrary.org/works/OL21676651W
+Kunst der Farbe,Johannes Itten,N/A,1961,https://openlibrary.org/works/OL3134338W
+A Stranger in the Mirror,Sidney Sheldon,N/A,1976,https://openlibrary.org/works/OL1881774W
+The Deep,Nick Cutter,N/A,2015,https://openlibrary.org/works/OL19086734W
+Midnight Whispers,V. C. Andrews,N/A,1991,https://openlibrary.org/works/OL134858W
+The Human Factor,Graham Greene,N/A,1803,https://openlibrary.org/works/OL106078W
+The Forgotten Warrior,Erin Hunter,N/A,2011,https://openlibrary.org/works/OL16509079W
+The Push,Ashley Audrain,N/A,2021,https://openlibrary.org/works/OL21694014W
+The Dawn of Everything,"David Graeber, David Wengrow",N/A,2021,https://openlibrary.org/works/OL24663287W
+Wilhelm Tell,Friedrich Schiller,N/A,1800,https://openlibrary.org/works/OL207638W
+Duineser Elegien,Rainer Maria Rilke,N/A,1923,https://openlibrary.org/works/OL3801010W
+Kaffir Boy,Mark Mathabane,N/A,1986,https://openlibrary.org/works/OL1907740W
+The Greek Tycoon's Virgin Wife,Helen Bianchin,N/A,2007,https://openlibrary.org/works/OL3498560W
+The Secret Language of Birthdays,"Gary Goldschneider, Joost Elffers",N/A,1992,https://openlibrary.org/works/OL40939W
+I Survived the Shark Attacks of 1916,"Lauren Tarshis, Haus Studio, Lauren Haus Studio, Scott Dawson",N/A,2010,https://openlibrary.org/works/OL16471761W
+The creature from Jekyll Island,G. Edward Griffin,N/A,1994,https://openlibrary.org/works/OL3007423W
+Cloud Cuckoo Land,"Anthony Doerr, Laura Vidal Sanz",N/A,2021,https://openlibrary.org/works/OL24164954W
+Aeneid,Virgil,N/A,1968,https://openlibrary.org/works/OL36655754W
+The Magic of Thinking Big,David Joseph Schwartz,N/A,1957,https://openlibrary.org/works/OL8108803W
+Tercer viaje al reino de la fantasía,"Elisabetta Dami, Titi Plumederat, David Nel·lo",N/A,2008,https://openlibrary.org/works/OL16798486W
+The way I feel,Janan Cain,N/A,2000,https://openlibrary.org/works/OL15852302W
+The Ontario readers,Ontario. Ministry of Education.,N/A,1884,https://openlibrary.org/works/OL9287385W
+The coming plague,Laurie Garrett,N/A,1994,https://openlibrary.org/works/OL3373979W
+The Phantom Rickshaw and Other Ghost Stories,Rudyard Kipling,N/A,1899,https://openlibrary.org/works/OL20123W
+El árbol de la ciencia,Pío Baroja,N/A,1911,https://openlibrary.org/works/OL745027W
+Sisters of the Yam,bell hooks,N/A,1993,https://openlibrary.org/works/OL31124W
+The Ballad of Never After,Stephanie Garber,N/A,2022,https://openlibrary.org/works/OL27090610W
+Mara Daughter of the Nile,Eloise Jarvis McGraw,N/A,1953,https://openlibrary.org/works/OL2951035W
+Fear Street - The Knife,Robert Lawrence Stine,N/A,1991,https://openlibrary.org/works/OL15094430W
+Debt,David Graeber,N/A,2011,https://openlibrary.org/works/OL14909099W
+The untethered soul,Michael A. Singer,N/A,2007,https://openlibrary.org/works/OL15845722W
+Firestar's Quest,Erin Hunter,N/A,2007,https://openlibrary.org/works/OL5714316W
+"Lavengro.   The Scholar, The Gypsy, The Priest",George Henry Borrow,N/A,1851,https://openlibrary.org/works/OL244663W
+The Rational Optimist,Matt Ridley,N/A,2010,https://openlibrary.org/works/OL14928967W
+The next person you meet in Heaven,Mitch Albom,N/A,1918,https://openlibrary.org/works/OL19749357W
+Winter Dreams,F. Scott Fitzgerald,N/A,2004,https://openlibrary.org/works/OL468503W
+New treasure seekers,Edith Nesbit,N/A,1904,https://openlibrary.org/works/OL99534W
+The Enchanted Island of Yew,L. Frank Baum,N/A,1903,https://openlibrary.org/works/OL262388W
+Firekeeper's Daughter,Angeline Boulley,N/A,2021,https://openlibrary.org/works/OL20805905W
+Medical apartheid,Harriet A. Washington,N/A,2006,https://openlibrary.org/works/OL5849823W
+"Creativity, Inc.","Ed Catmull, Amy Wallace",N/A,2001,https://openlibrary.org/works/OL17078912W
+Freedom from the known,Jiddu Krishnamurti,N/A,1959,https://openlibrary.org/works/OL587969W
+The Victorian age in literature,Gilbert Keith Chesterton,N/A,1913,https://openlibrary.org/works/OL76466W
+Legend,Marie Lu,N/A,2011,https://openlibrary.org/works/OL16334220W
+Redshirts,John Scalzi,N/A,2012,https://openlibrary.org/works/OL16564627W
+The American Claimant,Mark Twain,N/A,1881,https://openlibrary.org/works/OL54153W
+Fading Echoes,Erin Hunter,N/A,2010,https://openlibrary.org/works/OL5714273W
+Triplanetary,"E. D. Smith, Edward Elmer Smith, Frederick E. Smith, E. E. Smith, Edward E. Smith, “Doc” E.E. Smith, E. E. &quot;Doc&quot; Smith, E. E. Smith, E.E. ""Doc Smith, Edward Elmer  Smith, Edward ""Doc"" Smith, Edward Doc"" Smith",N/A,1948,https://openlibrary.org/works/OL2685469W
+"That was then, this is now",S. E. Hinton,N/A,1971,https://openlibrary.org/works/OL2718327W
+Innumeracy,John Allen Paulos,N/A,1988,https://openlibrary.org/works/OL1960756W
+Nils Holgerssons underbara resa genom Sverige,Selma Lagerlöf,N/A,1907,https://openlibrary.org/works/OL644990W
+I'll Give You the Sun,Jandy Nelson,N/A,2014,https://openlibrary.org/works/OL17081977W
+Mistero sull'Orient Express,Elisabetta Dami,N/A,2010,https://openlibrary.org/works/OL16805496W
+The Girl with All the Gifts,M. R. Carey,N/A,2014,https://openlibrary.org/works/OL17038327W
+The Way of Shadows,Brent Weeks,N/A,2008,https://openlibrary.org/works/OL15015332W
+Letters from a father to his daughter,Jawaharlal Nehru,N/A,1930,https://openlibrary.org/works/OL296153W
+The power of the dog,Thomas Savage,N/A,1967,https://openlibrary.org/works/OL4649200W
+Foster,Claire Keegan,N/A,1900,https://openlibrary.org/works/OL19956847W
+The secret of Father Brown,"Gilbert Keith Chesterton, Andronum (cover illustrator)",N/A,1927,https://openlibrary.org/works/OL76464W
+Pete the Cat. I Love My White Shoes,"Eric Litwin, James Dean",N/A,2008,https://openlibrary.org/works/OL15082793W
+"History of Egypt, Chaldea, Syria, Babylonia, And Assyria",Gaston Maspero,N/A,1901,https://openlibrary.org/works/OL1101827W
+The Atlas Six,Olivie Blake,N/A,2020,https://openlibrary.org/works/OL24339611W
+Leif the Lucky,"Ingri Parin D'Aulaire, Edgar Parin D'Aulaire",N/A,1941,https://openlibrary.org/works/OL4771359W
+Powerless,Lauren Roberts,N/A,2023,https://openlibrary.org/works/OL34774028W
+Maroo of the Winter Caves,Ann Turnbull,N/A,1984,https://openlibrary.org/works/OL2964475W
+How the King of Elfhame Learned to Hate Stories,"Holly Black, Rovina Cai, LitJoy Crate",N/A,2020,https://openlibrary.org/works/OL20831007W
+The Little Paris Bookshop,"Nina George, Nina George",N/A,2015,https://openlibrary.org/works/OL18020346W
+The Perfect Date,Robert Lawrence Stine,N/A,1996,https://openlibrary.org/works/OL72323W
+Maximum Ride. The Manga 1,NaRae Lee,N/A,2009,https://openlibrary.org/works/OL13770232W
+The Winds of War,Herman Wouk,N/A,1971,https://openlibrary.org/works/OL729146W
+Horus Rising,Dan Abnett,N/A,2006,https://openlibrary.org/works/OL5843391W
+Grande ritorno nel Regno della Fantasia 2,Elisabetta Dami,N/A,2011,https://openlibrary.org/works/OL17591401W
+Motivation and personality,Abraham H. Maslow,N/A,1954,https://openlibrary.org/works/OL1807541W
+"Teach Us, Amelia Bedelia","Peggy Parish, Lynn Sweat",N/A,1977,https://openlibrary.org/works/OL1932956W
+Station Eleven,Emily St. John Mandel,N/A,2014,https://openlibrary.org/works/OL17202418W
+A Burnt-Out Case,Graham Greene,N/A,1960,https://openlibrary.org/works/OL106080W
+Mathilda,Mary Shelley,N/A,1959,https://openlibrary.org/works/OL450120W
+Le crime d'Orcival,Émile Gaboriau,N/A,1867,https://openlibrary.org/works/OL1546081W
+The Truth About Stacey,Raina Telgemeier,N/A,2006,https://openlibrary.org/works/OL8756332W
+The Fear Street Saga - The Betrayal,Robert Lawrence Stine,N/A,1993,https://openlibrary.org/works/OL72408W
+Fences,August Wilson,N/A,1986,https://openlibrary.org/works/OL2983763W
+The Yellow Fairy Book (Large Print),"Andrew Lang, Henry Justice Ford, Henry Ford, Leonora Blanche Lang",N/A,1894,https://openlibrary.org/works/OL1088888W
+The sovereign individual,James Dale Davidson,N/A,1997,https://openlibrary.org/works/OL3350985W
+Fear Street - The Surprise Party,Robert Lawrence Stine,N/A,1989,https://openlibrary.org/works/OL72342W
+Five minutes' peace,Jill Murphy,N/A,1986,https://openlibrary.org/works/OL496120W
+Introduction to Algorithms,"Thomas H. Cormen, Charles E. Leiserson, Ronald L. Rivest, Clifford Stein",N/A,1990,https://openlibrary.org/works/OL4781294W
+Summer Knight,Jim Butcher,N/A,2002,https://openlibrary.org/works/OL5961786W
+The Lost Metal,Brandon Sanderson,N/A,2022,https://openlibrary.org/works/OL26769924W
+The Labyrinth of Solitude,Octavio Paz,N/A,1961,https://openlibrary.org/works/OL743252W
+Aspects of the novel,"E. M. Forster, Oliver Stallybrass",N/A,1927,https://openlibrary.org/works/OL88875W
+Emperor Mage (Immortals #3),Tamora Pierce,N/A,1994,https://openlibrary.org/works/OL29247W
+The Freedom Writers Diary,"Erin Gruwell, Freedom Writers., Freedom Writers, Zlata Filipović, The Freedom Writers",N/A,1999,https://openlibrary.org/works/OL8526561W
+The Signal-man,"Charles Dickens, Sajad Hussain",N/A,1972,https://openlibrary.org/works/OL14869543W
+Grande Ritorno Nel Regno Della Fantasia,Elisabetta Dami,N/A,2007,https://openlibrary.org/works/OL17063347W
+Percy Jackson's Greek heroes,Rick Riordan,N/A,2015,https://openlibrary.org/works/OL19669249W
+The defining decade,Meg Jay,N/A,2012,https://openlibrary.org/works/OL16263576W
+Why men don't listen & women can't read maps,"Barbara Pease, Allan Pease",N/A,1998,https://openlibrary.org/works/OL5847081W
+The Red Scrolls of Magic,"Wesley Chu, Cassandra Clare",N/A,2019,https://openlibrary.org/works/OL20480768W
+Marriage on the Rebound,Michelle Reid,N/A,1997,https://openlibrary.org/works/OL4233136W
+The Gift of Loving,Patricia Wilson,N/A,1991,https://openlibrary.org/works/OL8315358W
+On Beauty,"Zadie Smith, Peter Francis James, Adjoa Andoh, Philippe Aronson, Ana María de la Fuente Suárez",N/A,2005,https://openlibrary.org/works/OL481148W
+Empire of Pain,"Patrick Radden Keefe, Ricard Gil",N/A,2021,https://openlibrary.org/works/OL24218388W
+Journey to Topaz,Yoshiko Uchida,N/A,1971,https://openlibrary.org/works/OL2617001W
+On the Same Day in March,"Marilyn Singer, Frane Lessac",N/A,2000,https://openlibrary.org/works/OL1898929W
+Battlefield of the Mind,Joyce Meyer,N/A,1995,https://openlibrary.org/works/OL803597W
+Cleopatra,H. Rider Haggard,N/A,1889,https://openlibrary.org/works/OL17531W
+The ball and the cross,"Gilbert Keith Chesterton, Damian Andre",N/A,1909,https://openlibrary.org/works/OL76470W
+The Priory of the Orange Tree,"Samantha Shannon, Jorge Rizzo",N/A,2018,https://openlibrary.org/works/OL20157354W
+The Stranger at the Pentagon,Frank E. Stranges,N/A,1967,https://openlibrary.org/works/OL2164769W
+How to Make Friends with the Dark,Kathleen Glasgow,N/A,2019,https://openlibrary.org/works/OL20149092W
+The Dangerous Gift,Tui T. Sutherland,N/A,2020,https://openlibrary.org/works/OL20895325W
+The Complete Book of Magic and Witchcraft,Kathryn Paulsen,N/A,1970,https://openlibrary.org/works/OL7302648W
+I Survived,"Lauren Tarshis, Jennifer Bronstein, Scott Dawson",N/A,2012,https://openlibrary.org/works/OL17104595W
+How to Be an Antiracist,"Ibram X. Kendi, Cristina Lizarbe",N/A,2019,https://openlibrary.org/works/OL20086330W
+The Age of Surveillance Capitalism,Shoshana Zuboff,N/A,2018,https://openlibrary.org/works/OL18201749W
+Leo the Late Bloomer,Robert Kraus,N/A,1971,https://openlibrary.org/works/OL99687W
+Tarot,Eileen Connolly,N/A,1979,https://openlibrary.org/works/OL4519185W
+The House of the Scorpion,Nancy Farmer,N/A,2002,https://openlibrary.org/works/OL2696044W
+The light we lost,Jill Santopolo,N/A,2017,https://openlibrary.org/works/OL20053653W
+Conan,Robert E. Howard,N/A,1967,https://openlibrary.org/works/OL3384310W
+Arc de triomphe,Erich Maria Remarque,N/A,1945,https://openlibrary.org/works/OL1209319W
+The Affair at the Semiramis Hotel,A. E. W. Mason,N/A,1917,https://openlibrary.org/works/OL532398W
+1980 census of housing,United States. Bureau of the Census,N/A,1983,https://openlibrary.org/works/OL33456453W
+Scorpia,Anthony Horowitz,N/A,2004,https://openlibrary.org/works/OL80761W
+The Bear and the Nightingale,Katherine Arden,N/A,2017,https://openlibrary.org/works/OL19622946W
+The museum experience revisited,"John H. Falk, Lynn D. Dierking, Marsha Semmel",N/A,1992,https://openlibrary.org/works/OL16705133W
+The Ultimate Betrayal,Michelle Reid,N/A,1995,https://openlibrary.org/works/OL4233169W
+Permanent Record,Edward Snowden,N/A,2019,https://openlibrary.org/works/OL20080323W
+How to Master the Art of Selling,Tom Hopkins,N/A,1980,https://openlibrary.org/works/OL2033583W
+La Nuit des temps,René Barjavel,N/A,1968,https://openlibrary.org/works/OL8551775W
+Prisoners of geography,Tim Marshall,N/A,2015,https://openlibrary.org/works/OL20010115W
+The Love Hypothesis,Ali Hazelwood,N/A,2021,https://openlibrary.org/works/OL24178205W
+The dragon can't dance,Earl Lovelace,N/A,1979,https://openlibrary.org/works/OL1845067W
+Séptimo viaje al reino de la fantasía,"Elisabetta Dami, David Nel·lo",N/A,2011,https://openlibrary.org/works/OL16798490W
+The Sicilian's Ruthless Marriage Revenge,Carole Mortimer,N/A,2007,https://openlibrary.org/works/OL3775369W
+Legacy (Keeper of the Lost Cities #8),Shannon Messenger,N/A,2019,https://openlibrary.org/works/OL20653806W
+Bread givers,Anzia Yezierska,N/A,1925,https://openlibrary.org/works/OL14866180W
+Doomsday book,Connie Willis,N/A,1992,https://openlibrary.org/works/OL14858406W
+How to Write a Movie in 21 Days,Viki King,N/A,1988,https://openlibrary.org/works/OL4114917W
+Herbal medicine,"Dian Dincin Buchman, DIAN DINCIN. BUCHMAN",N/A,1979,https://openlibrary.org/works/OL2569571W
+Libro de los seres imaginarios,Jorge Luis Borges,N/A,1967,https://openlibrary.org/works/OL110962W
+Les Amities Particulaires,Roger Peyrefitte,N/A,1945,https://openlibrary.org/works/OL2434523W
+A Court of Silver Flames,Sarah J. Maas,N/A,2021,https://openlibrary.org/works/OL21703979W
+The 21 Irrefutable Laws of Leadership,John C. Maxwell,N/A,1998,https://openlibrary.org/works/OL28124W
+Psychology and life,Floyd Leon Ruch,N/A,1937,https://openlibrary.org/works/OL1592929W
+The Wings of the Dove,Henry James,N/A,1902,https://openlibrary.org/works/OL276397W
+"The power of birthdays, stars & numbers",Saffi Crawford,N/A,1998,https://openlibrary.org/works/OL1857358W
+Ceremony,"Leslie Silko, Silko, Leslie Marmon Silko",N/A,1977,https://openlibrary.org/works/OL2004614W
+Lost connections,Johann Hari,N/A,2018,https://openlibrary.org/works/OL19729600W
+The Daydreamer,Ian McEwan,N/A,1994,https://openlibrary.org/works/OL1855936W
+The Crisscross Shadow,Franklin W. Dixon,N/A,1953,https://openlibrary.org/works/OL39954W
+Fear Street - The Confession,Robert Lawrence Stine,N/A,1996,https://openlibrary.org/works/OL72242W
+2 states,Chetan Bhagat,N/A,2009,https://openlibrary.org/works/OL15029319W
+The Terror,Arthur Machen,N/A,1917,https://openlibrary.org/works/OL3389026W
+Satirae,Horace,N/A,1763,https://openlibrary.org/works/OL15249113W
+Tous les hommes sont mortels,Simone de Beauvoir,N/A,1946,https://openlibrary.org/works/OL767769W
+Alone with You in the Ether,Olivie Blake,N/A,2020,https://openlibrary.org/works/OL27774839W
+Getting the love you want,Harville Hendrix,N/A,1988,https://openlibrary.org/works/OL2998757W
+The Island of Adventure,Enid Blyton,N/A,1944,https://openlibrary.org/works/OL1948161W
+Of water and the spirit,"Malidoma Patrice Somé, Malidoma Patrice Some",N/A,1994,https://openlibrary.org/works/OL1887737W
+The Host,Stephenie Meyer,N/A,2008,https://openlibrary.org/works/OL5720033W
+The concubine,Elechi Amadi,N/A,1966,https://openlibrary.org/works/OL4921279W
+Punished by Rewards,Alfie Kohn,N/A,1993,https://openlibrary.org/works/OL1908441W
+The Hating Game,Sally Thorne,N/A,2016,https://openlibrary.org/works/OL20032935W
+The slave community,"John W. Blassingame, John W. Blassingame",N/A,1972,https://openlibrary.org/works/OL6808599W
+The compound effect,Darren Hardy,N/A,2010,https://openlibrary.org/works/OL20015609W
+International Relations,"Joshua S. Goldstein, Jon C. Pevehouse, Jon C. Pevehouse",N/A,1994,https://openlibrary.org/works/OL1887437W
+Tales from the Shadowhunter Academy,"Cassandra Clare, Sarah Rees Brennan, Maureen Johnson, Robin Wasserman",N/A,2016,https://openlibrary.org/works/OL19340381W
+Identity and the life cycle,Erik H. Erikson,N/A,1959,https://openlibrary.org/works/OL1194362W
+John Dies at the End,David Wong,N/A,2007,https://openlibrary.org/works/OL8378245W
+Old Man’s War,John Scalzi,N/A,2005,https://openlibrary.org/works/OL5734647W
+Nectar in a sieve,Kamala Markandaya,N/A,1954,https://openlibrary.org/works/OL5413105W
+A Gathering of Old Men,Ernest J. Gaines,N/A,1983,https://openlibrary.org/works/OL2547243W
+Wild seed,Octavia E. Butler,N/A,1980,https://openlibrary.org/works/OL35627W
+Talons of Power,Tui T. Sutherland,N/A,2016,https://openlibrary.org/works/OL17616104W
+Analysis for financial management,Robert C. Higgins,N/A,1983,https://openlibrary.org/works/OL2667692W
+Fingerprints of the gods,Graham Hancock,N/A,1995,https://openlibrary.org/works/OL15016014W
+Talk Like TED,Carmine Gallo,N/A,2014,https://openlibrary.org/works/OL17076301W
+David goes to school,"David Shannon, Teresa Mlawer",N/A,1999,https://openlibrary.org/works/OL547369W
+Composition Book,Harriet Flora,N/A,2020,https://openlibrary.org/works/OL30575577W
+"Man, the manipulator",Everett L. Shostrom,N/A,1967,https://openlibrary.org/works/OL4465084W
+The Beginning of Infinity,David Deutsch,N/A,2008,https://openlibrary.org/works/OL4325174W
+Fourth Wing - The Empyrean #1,Rebecca Yarros,N/A,2023,https://openlibrary.org/works/OL29226517W
+Drawing down the Moon,Margot Adler,N/A,1979,https://openlibrary.org/works/OL2849822W
+Poems verses words of rhyme,Jumpin Media Books,N/A,2018,https://openlibrary.org/works/OL20538257W
+Ragged Dick,"Horatio Alger, Jr.",N/A,1868,https://openlibrary.org/works/OL2341714W
+Nevermoor,Jessica Townsend,N/A,2017,https://openlibrary.org/works/OL19347138W
+Bloodlands,Timothy Snyder,N/A,2010,https://openlibrary.org/works/OL15688711W
+"The Sea, the Sea",Iris Murdoch,N/A,1978,https://openlibrary.org/works/OL1326310W
+The grammar of ornament,Owen Jones,N/A,1856,https://openlibrary.org/works/OL15836693W
+How to Change Your Mind,Michael Pollan,N/A,2018,https://openlibrary.org/works/OL20159801W
+The Secret His Mistress Carried,Lynne Graham,N/A,2014,https://openlibrary.org/works/OL17924222W
+The Bullet Journal method,Ryder Carroll,N/A,2018,https://openlibrary.org/works/OL19764772W
+The Legend of the Seventh Virgin,Victoria Holt,N/A,1964,https://openlibrary.org/works/OL3931484W
+"Taking Charge of Your Fertility, 10th Anniversary Edition","Toni Weschler, Toni Weschler",N/A,1995,https://openlibrary.org/works/OL2908483W
+The gap in the curtain,John Buchan,N/A,1900,https://openlibrary.org/works/OL76566W
+The top five regrets of the dying,Bronnie Ware,N/A,2011,https://openlibrary.org/works/OL16730132W
+"Dear Ijeawele, or A Feminist Manifesto in Fifteen Suggestions",Chimamanda Ngozi Adichie,N/A,2017,https://openlibrary.org/works/OL17640883W
+La Gara Dei Supercuochi,Elisabetta Dami,N/A,2012,https://openlibrary.org/works/OL19985136W
+Actions and Reactions,Rudyard Kipling,N/A,1909,https://openlibrary.org/works/OL20156W
+Směšné lásky,Milan Kundera,N/A,1965,https://openlibrary.org/works/OL10423420W
+The Citadel,A. J. Cronin,N/A,1937,https://openlibrary.org/works/OL4189809W
+Fear Street - The New Boy,Robert Lawrence Stine,N/A,1993,https://openlibrary.org/works/OL72311W
+Hallucinations,Oliver Sacks,N/A,2012,https://openlibrary.org/works/OL16490291W
+Le Côté de Guermantes,Marcel Proust,N/A,1920,https://openlibrary.org/works/OL27213717W
+Never Split the Difference,"Chris Voss, Tahl Raz",N/A,2016,https://openlibrary.org/works/OL18819818W
+Storia del nuovo cognome,Elena Ferrante,N/A,2012,https://openlibrary.org/works/OL16807901W
+Mastery,Robert Greene,N/A,2012,https://openlibrary.org/works/OL17429337W
+The Queen of Nothing,"Holly Black, Caitlin Kelly, LitJoy Crate",N/A,2019,https://openlibrary.org/works/OL20485895W
+The Greek's Forced Bride,Michelle Reid,N/A,2008,https://openlibrary.org/works/OL4233123W
+George's Secret Key to the Universe,"Stephen Hawking, Lucy Hawking, Hugh Dancy",N/A,1998,https://openlibrary.org/works/OL5714585W
+Diabetes Tagebuch,Karl Simpson,N/A,2020,https://openlibrary.org/works/OL21934297W
+The Book of Life,Deborah Harkness,N/A,2014,https://openlibrary.org/works/OL17782786W
+The Dialogues of Plato / The Seventh Letter,Πλάτων,N/A,1952,https://openlibrary.org/works/OL15100036W
+The Fever Code,James Dashner,N/A,2016,https://openlibrary.org/works/OL18159946W
+I Have Lived a Thousand Years,Livia Bitton-Jackson,N/A,1997,https://openlibrary.org/works/OL8199548W
+Effective business communications,Herta A. Murphy,N/A,1972,https://openlibrary.org/works/OL15830350W
+Demigods & magicians,Rick Riordan,N/A,2014,https://openlibrary.org/works/OL20024798W
+The woman in black,Susan Hill,N/A,1984,https://openlibrary.org/works/OL937096W
+Virgin for the Billionaire's Taking,Penny Jordan,N/A,2008,https://openlibrary.org/works/OL13693163W
+The heart of the matter,Graham Greene,N/A,1948,https://openlibrary.org/works/OL106077W
+We'll Always Have Summer,Jenny Han,N/A,2011,https://openlibrary.org/works/OL16211977W
+Zapiski okhotnika,Ivan Sergeevich Turgenev,N/A,1895,https://openlibrary.org/works/OL43369W
+Star Wars - The Old Republic - Revan,"Drew Karpyshyn, Diego de los Santos",N/A,2011,https://openlibrary.org/works/OL16529286W
+The Velvet Tiger,Emma Darcy,N/A,1992,https://openlibrary.org/works/OL2959374W
+The Heiress Bride,Lynne Graham,N/A,2002,https://openlibrary.org/works/OL3773927W
+Das Mädchen Anne Frank,Melissa Müller,N/A,1998,https://openlibrary.org/works/OL1897469W
+Only One Left,Todd Ritter,N/A,2023,https://openlibrary.org/works/OL29211540W
+Salt to the Sea,Ruta Sepetys,N/A,2016,https://openlibrary.org/works/OL17359139W
+Canne al vento,"Grazia Deledda, Qem Classic, A. Tuccillo, Martha King, Dolores Turchi, Guro Verlag",N/A,1913,https://openlibrary.org/works/OL1438050W
+The Lottery,Shirley Jackson,N/A,1983,https://openlibrary.org/works/OL3171085W
+The cat who walks through walls,Robert A. Heinlein,N/A,1985,https://openlibrary.org/works/OL59700W
+The Goblin Emperor,Sarah Monette,N/A,2014,https://openlibrary.org/works/OL17270804W
+Communion,"bell hooks, Montserrat Asensio Fernández",N/A,2002,https://openlibrary.org/works/OL277285W
+The War I Finally Won,"Kimberly Brubaker Bradley, Josie Portillo",N/A,2017,https://openlibrary.org/works/OL19352868W
+Black Feminist Thought,Patricia Hill Collins,N/A,1990,https://openlibrary.org/works/OL1870600W
+The Andromeda Strain,Michael Crichton,N/A,1969,https://openlibrary.org/works/OL46909W
+Salt,Mark Kurlansky,N/A,2002,https://openlibrary.org/works/OL2652890W
+Как закалялась сталь,Nikolay Ostrovsky,N/A,1936,https://openlibrary.org/works/OL5174423W
+In the Dream House,Carmen Maria Machado,N/A,2019,https://openlibrary.org/works/OL20470143W
+A light in the attic,Shel Silverstein,N/A,1981,https://openlibrary.org/works/OL15843795W
+Chip War,"Chris Miller, Chris Miller",N/A,2022,https://openlibrary.org/works/OL27846746W
+The Lost Stradivarius,John Meade Falkner,N/A,1895,https://openlibrary.org/works/OL1352095W
+"After (After Series, Book 1)",Anna Todd,N/A,2014,https://openlibrary.org/works/OL17719508W
+Final del juego,Julio Cortázar,N/A,1956,https://openlibrary.org/works/OL276963W
+Oakleaf Bearers,John Flanagan,N/A,2006,https://openlibrary.org/works/OL7988552W
+The Crush,Sandra Brown,N/A,2002,https://openlibrary.org/works/OL167333W
+Fear Street - The Rich Girl,Robert Lawrence Stine,N/A,1997,https://openlibrary.org/works/OL9964696W
+The Path of the King,John Buchan,N/A,1921,https://openlibrary.org/works/OL76594W
+Sommarboken,Tove Jansson,N/A,1972,https://openlibrary.org/works/OL2196010W
+The better angels of our nature,Steven Pinker,N/A,2011,https://openlibrary.org/works/OL16239379W
+The Jester,"James Patterson, Andrew Gross",N/A,2003,https://openlibrary.org/works/OL167161W
+The antecedents of self-esteem / Stanley Coopersmith,"Stanley Coopersmith, Stanley Coopersmith",N/A,1967,https://openlibrary.org/works/OL3607143W
+Still Me,Jojo Moyes,N/A,2018,https://openlibrary.org/works/OL17838448W
+Back to Methuselah,George Bernard Shaw,N/A,1921,https://openlibrary.org/works/OL1066519W
+Tress of the Emerald Sea,Brandon Sanderson,N/A,2023,https://openlibrary.org/works/OL28687656W
+A Living Nightmare... (Cirque Du Freak #1),Darren Shan,N/A,2000,https://openlibrary.org/works/OL5727123W
+Onyx Storm,Rebecca Yarros,N/A,2025,https://openlibrary.org/works/OL41943074W
+The happiness advantage,Shawn Achor,N/A,2010,https://openlibrary.org/works/OL15674042W
+The developing person through the life span,Kathleen Stassen Berger,N/A,1983,https://openlibrary.org/works/OL513403W
+The Checklist Manifesto,Atul Gawande,N/A,2010,https://openlibrary.org/works/OL15436462W
+Fear Street - The Boy Next Door,Robert Lawrence Stine,N/A,1996,https://openlibrary.org/works/OL72233W
+The language of letting go,Melody Beattie,N/A,1990,https://openlibrary.org/works/OL45920W
+Illuminae,"Amie Kaufman, Jay Kristoff",N/A,2014,https://openlibrary.org/works/OL17332741W
+How I learned to drive,Paula Vogel,N/A,1997,https://openlibrary.org/works/OL2108613W
+Ben and Me,"Robert Lawson, Kazuko Komine",N/A,1923,https://openlibrary.org/works/OL4234947W
+Gray Hat Hacking,"Shon Harris, Allen Harper, Daniel Regalado, Ryan Linn, Stephen Sims, Branko Spasojevic, Linda Martinez, Michael Baucom, Chris Eagle, Jonathan Ness",N/A,2004,https://openlibrary.org/works/OL15111477W
+If I die in a combat zone box me up and ship me home,Tim O'Brien,N/A,1969,https://openlibrary.org/works/OL22428W
+The carpetbaggers,"Harold Robbins, Robbins                      H",N/A,1961,https://openlibrary.org/works/OL1816253W
+キッチン,吉本 ばなな,N/A,1988,https://openlibrary.org/works/OL2637599W
+Story Books,UCT School of Education,N/A,1995,https://openlibrary.org/works/OL9521135W
+"Esther Waters, a novel",George Moore,N/A,1890,https://openlibrary.org/works/OL1381165W
+Metodo della pedagogia scientifica,Maria Montessori,N/A,1912,https://openlibrary.org/works/OL1542661W
+This is my God,Herman Wouk,N/A,1959,https://openlibrary.org/works/OL729145W
+Harrow the Ninth,Tamsyn Muir,N/A,2020,https://openlibrary.org/works/OL20723256W
+Dark Matter,Blake Crouch,N/A,2016,https://openlibrary.org/works/OL17358795W
+Hidden bodies,Caroline Kepnes,N/A,2016,https://openlibrary.org/works/OL20005800W
+Champion,"Marie Lu, Steven Kaplan, Mariel Stern",N/A,2013,https://openlibrary.org/works/OL17092593W
+The Mitrokhin Archive II,"Christopher M. Andrew, CHRISTOPHER M. ANDREW, Christopher Andrew, Wassili Mitrochin",N/A,2005,https://openlibrary.org/works/OL894893W
+The face in the abyss,A. Merritt,N/A,1931,https://openlibrary.org/works/OL4104764W
+Daughter of the Siren Queen,Tricia Levenseller,N/A,2018,https://openlibrary.org/works/OL19737592W
+Rendicion Inocente,Sara Craven,N/A,2009,https://openlibrary.org/works/OL17733454W
+Once and Always,Judith McNaught,N/A,1987,https://openlibrary.org/works/OL152331W
+Shapes in the Sky: A Book About Clouds (Amazing Science: Weather),"Josepha Sherman, Omarr Wesley",N/A,2003,https://openlibrary.org/works/OL742483W
+The Ruins of Gorlan,John Flanagan,N/A,2004,https://openlibrary.org/works/OL7988545W
+She Who Became the Sun,Shelley Parker-Chan,N/A,2021,https://openlibrary.org/works/OL24184009W
+The Parasite,Arthur Conan Doyle,N/A,1894,https://openlibrary.org/works/OL262564W
+Patternmaking for fashion design,Helen Joseph Armstrong,N/A,1987,https://openlibrary.org/works/OL3514475W
+The anatomy of motive,"John E. Douglas, John Douglas, Mark Olshaker",N/A,1999,https://openlibrary.org/works/OL15211798W
+The case for Christ,Lee Strobel,N/A,1998,https://openlibrary.org/works/OL1827692W
+The Navigator,"Clive Cussler, Paul Kemprecos",N/A,2005,https://openlibrary.org/works/OL84879W
+The Ultimate Sales Machine,Chet Holmes,N/A,2007,https://openlibrary.org/works/OL9176664W
+The Hundred Years' War on Palestine,"Rashid Khalidi, Francisco Ramos",N/A,2020,https://openlibrary.org/works/OL20667220W
+Radical acceptance,"Tara Brach, Cassandra Campbell, Alejandro Pareja Rodríguez",N/A,2003,https://openlibrary.org/works/OL15844781W
+Wild at Heart,John Eldredge,N/A,2001,https://openlibrary.org/works/OL4046227W
+Fear Street - Halloween Party,Robert Lawrence Stine,N/A,1990,https://openlibrary.org/works/OL72384W
+How to Make Money in Stocks,William J. O'Neil,N/A,1988,https://openlibrary.org/works/OL3498124W
+Salute to Adventurers,John Buchan,N/A,1900,https://openlibrary.org/works/OL76590W
+Do you want to be my friend?,Eric Carle,N/A,1971,https://openlibrary.org/works/OL52967W
+The life cycle completed,Erik H. Erikson,N/A,1982,https://openlibrary.org/works/OL1194361W
+Brewster's millions,George Barr McCutcheon,N/A,1902,https://openlibrary.org/works/OL24259W
+"Mujeres, Raza Y Clase (Cuestiones De Antagonismo)","Angela Y. Davis, Ana Varela Mateos, Pastora Filigrana Garcia",N/A,1981,https://openlibrary.org/works/OL2709375W
+Feminist theory,"bell hooks, Noomi B. Grüsig, Nassira Hedjerassi",N/A,1984,https://openlibrary.org/works/OL31115W
+How to read literature like a professor,Thomas C. Foster,N/A,2002,https://openlibrary.org/works/OL3457506W
+The Vampire Diaries,Lisa Jane Smith,N/A,1991,https://openlibrary.org/works/OL19089954W
+The Poison Jungle,Tui T. Sutherland,N/A,2019,https://openlibrary.org/works/OL19665944W
+Night Chills,Dean Koontz,N/A,1976,https://openlibrary.org/works/OL263291W
+Lo smeraldo del principe indiano,Elisabetta Dami,N/A,2010,https://openlibrary.org/works/OL16796139W
+The diagnosis & correction of vocal faults,James C. McKinney,N/A,1982,https://openlibrary.org/works/OL1704587W
+Astérix Légionnaire,"René Goscinny, Albert Uderzo",N/A,1967,https://openlibrary.org/works/OL267636W
+Replay,Ken Grimwood,N/A,1986,https://openlibrary.org/works/OL2252098W
+The Flying Inn,Gilbert Keith Chesterton,N/A,1914,https://openlibrary.org/works/OL76344W
+The 57 Bus,Dashka Slater,N/A,2017,https://openlibrary.org/works/OL17856784W
+Neverseen,Shannon Messenger,N/A,2015,https://openlibrary.org/works/OL17714887W
+Physics of the Impossible,Michio Kaku,N/A,2008,https://openlibrary.org/works/OL14861736W
+The Arrival,Shaun Tan,N/A,2006,https://openlibrary.org/works/OL5934430W
+The Toothpaste Millionaire,Jean Merrill,N/A,1972,https://openlibrary.org/works/OL4104666W
+Falkner,Mary Shelley,N/A,1837,https://openlibrary.org/works/OL449979W
+Beneath the Attic,V. C. Andrews,N/A,2019,https://openlibrary.org/works/OL20104759W
+The Devil's Pawn,Yvonne Whittal,N/A,1984,https://openlibrary.org/works/OL4225435W
+The Flawed Marriage,Penny Jordan,N/A,1983,https://openlibrary.org/works/OL11327946W
+The Hut Six Story,Gordon Welchman,N/A,1982,https://openlibrary.org/works/OL2112420W
+Spook Who Sat by Door,"Sam Greenlee, Sam Greenlee, Natiki Hope Pressley",N/A,1969,https://openlibrary.org/works/OL4802234W
+The Flatshare,Beth O'Leary,N/A,2019,https://openlibrary.org/works/OL20664315W
+Atlas of the Heart,Brené Brown,N/A,2021,https://openlibrary.org/works/OL25023471W
+Daughter of the pirate king,Tricia Levenseller,N/A,2017,https://openlibrary.org/works/OL19737591W
+Full catastrophe living,Jon Kabat-Zinn,N/A,1990,https://openlibrary.org/works/OL3930535W
+On photography,Susan Sontag,N/A,1977,https://openlibrary.org/works/OL496476W
+Snow,Orhan Pamuk,N/A,2002,https://openlibrary.org/works/OL16064734W
+Shanna,Kathleen E. Woodiwiss,N/A,1977,https://openlibrary.org/works/OL59384W
+In Dubious Battle,John Steinbeck,N/A,1936,https://openlibrary.org/works/OL23198W
+"Thank You, Amelia Bedelia","Peggy Parish, Fritz Siebel",N/A,1964,https://openlibrary.org/works/OL1932991W
+An Old-Fashioned Girl,Betty Neels,N/A,1992,https://openlibrary.org/works/OL3457832W
+Hood Feminism,Mikki Kendall,N/A,2020,https://openlibrary.org/works/OL20652336W
+Stories of Your Life and Others,Ted Chiang,N/A,2002,https://openlibrary.org/works/OL6216050W
+Edda,Snorri Sturluson,N/A,1665,https://openlibrary.org/works/OL1133520W
+The Butterfly and the Baron,Margaret Way,N/A,1979,https://openlibrary.org/works/OL5236211W
+Love and Mr. Lewisham,H. G. Wells,N/A,1899,https://openlibrary.org/works/OL52259W
+Constitución política (1917),"Mexico., Mexico",N/A,1917,https://openlibrary.org/works/OL569770W
+He Comes Next,Ian Kerner,N/A,2006,https://openlibrary.org/works/OL5738201W
+Henri Matisse,"Henri Matisse, Olivier Berggruen, Max Hollein",N/A,1920,https://openlibrary.org/works/OL1227094W
+Cat Ninja,"Matthew Cody, Yehudi Mercado",N/A,2020,https://openlibrary.org/works/OL23613066W
+The language of the night,Ursula K. Le Guin,N/A,1979,https://openlibrary.org/works/OL59849W
+The great white queen,William Le Queux,N/A,1890,https://openlibrary.org/works/OL810480W
+Goals! How to Get Everything You Want--Faster Than You Ever Thought Possible,Brian Tracy,N/A,2003,https://openlibrary.org/works/OL2392330W
+The Culture Map,Erin Meyer,N/A,2014,https://openlibrary.org/works/OL19982879W
+Micah Clarke,Arthur Conan Doyle,N/A,1889,https://openlibrary.org/works/OL262588W
+Prison Healer,Lynette Noni,N/A,2021,https://openlibrary.org/works/OL22011552W
+Remarkably Bright Creatures,Shelby Van Pelt,N/A,2022,https://openlibrary.org/works/OL25382083W
+Harcourt Science,Houghton Mifflin Harcourt Staff,N/A,2008,https://openlibrary.org/works/OL27467261W
+Awakenings,"Oliver Sacks, Jonathan Davis",N/A,1973,https://openlibrary.org/works/OL1811911W
+The dictator's handbook,"Bruce Bueno de Mesquita, Alastair Smith, Bruce Bueno de Mesquita",N/A,2011,https://openlibrary.org/works/OL15980652W
+Let's go play at the Adams',Mendal W. Johnson,N/A,1974,https://openlibrary.org/works/OL7118113W
+Luces de bohemia,Ramón del Valle Inclán,N/A,1924,https://openlibrary.org/works/OL26419966W
+Hamlet,William Shakespeare,N/A,1982,https://openlibrary.org/works/OL26055683W
+Attack of the Jack-o'-lanterns,Robert Lawrence Stine,N/A,1996,https://openlibrary.org/works/OL72405W
+Everything I Know About Love,Dolly Alderton,N/A,2018,https://openlibrary.org/works/OL20654212W
+Houghton Mifflin Reading Leveled Readers California,Houghton Mifflin Company Staff,N/A,2009,https://openlibrary.org/works/OL27468059W
+Remember Me 2,Christopher Pike,N/A,1994,https://openlibrary.org/works/OL1000795W
+Don't let the pigeon stay up late!,Mo Willems,N/A,2006,https://openlibrary.org/works/OL5759999W
+The Brown Fairy Book (Large Print),"Andrew Lang, Henry Justice Ford, H. J. 1860-1941 Ford",N/A,1904,https://openlibrary.org/works/OL1088779W
+"Again, Dangerous Visions","Harlan Ellison, John Heidenry, Ross Rocklynne, Ursula K. Le Guin, Andrew J. Offutt, Gene Wolfe, Ray Nelson, Ray Bradbury, Chad Oliver, Edward Bryant, Kate Wilhelm, James B. Hemesath, Joanna Russ, Kurt Vonnegut, T. L. Sherred, K. M. O'Donnell, H. H. Hollis, Bernard Wolfe, David Gerrold, Piers Anthony, Lee Hoffman, Gahan Wilson, Joan Bernott, Gregory Benford, Evelyn Lief, James Sallis, Josephine Saxton, Ken McCullough, David Kerr, Burt K. Filer, Richard Hill, Leonard Tushnet, Ben Bova, Edward Gorman, James Blish, A. Parra, Thomas M. Disch, Richard A. Lupoff, John Harrison, Robin Scott, Andrew Weiner, Terry Carr, James Tiptree, Jr., Dean Koontz, Piers Anthony, Ben Bova",N/A,1967,https://openlibrary.org/works/OL1737310W
+She Stoops To Conquer,Oliver Goldsmith,N/A,1773,https://openlibrary.org/works/OL7981267W
+The Things We Cannot Say,Kelly Rimmer,N/A,2019,https://openlibrary.org/works/OL20312143W
+Founding Brothers,Joseph J. Ellis,N/A,2000,https://openlibrary.org/works/OL53120W
+The total money makeover,Dave Ramsey,N/A,2003,https://openlibrary.org/works/OL16027047W
+The Funhouse,Dean Koontz,N/A,1980,https://openlibrary.org/works/OL263249W
+The Wall of Winnipeg and Me,Mariana Zapata,N/A,2016,https://openlibrary.org/works/OL20900214W
+The Hand of Fu-Manchu,Sax Rohmer,N/A,1917,https://openlibrary.org/works/OL2288675W
+Feminine Psychology,Karen Horney,N/A,1967,https://openlibrary.org/works/OL98942W
+Dopamine Nation,Anna Lembke,N/A,2021,https://openlibrary.org/works/OL24868953W
+Old Possum's book of practical cats,T. S. Eliot,N/A,1939,https://openlibrary.org/works/OL1142289W
+The scapegoat,Daphne du Maurier,N/A,1900,https://openlibrary.org/works/OL36626W
+Blank Cookbook,"The Best & Coolest Journals Publishing, Recipe Journal",N/A,2016,https://openlibrary.org/works/OL40308756W
+Architectural graphic standards,"Charles George Ramsey, Harold Reeve Sleeper",N/A,1970,https://openlibrary.org/works/OL550047W
+Gideon the Ninth,Tamsyn Muir,N/A,2019,https://openlibrary.org/works/OL20128158W
+The Ten Thousand Doors of January,Alix E. Harrow,N/A,2019,https://openlibrary.org/works/OL20074045W
+Algorithms to Live By,"Brian Christian, Tom Griffiths",N/A,2016,https://openlibrary.org/works/OL17357767W
+The wisdom of psychopaths,Kevin Dutton,N/A,2012,https://openlibrary.org/works/OL16672514W
+"Good Strategy, Bad Strategy",Richard P. Rumelt,N/A,2011,https://openlibrary.org/works/OL16149072W
+"Sing, Unburied, Sing",Jesmyn Ward,N/A,2017,https://openlibrary.org/works/OL17826879W
+How Democracies Die,"Steven Levitsky, Daniel Ziblatt",N/A,2017,https://openlibrary.org/works/OL18139175W
+Bulldog Drummond,Herman Cyril McNeile,N/A,1919,https://openlibrary.org/works/OL241909W
+"Report of the superintending school committee of the Town of Lee, N.H. for the year ending .","Town of Lee, New Hampshire",N/A,2008,https://openlibrary.org/works/OL12294624W
+Fishing Log,Harold RIVERA,N/A,2022,https://openlibrary.org/works/OL28083981W
+The 12th Planet,Zecharia Sitchin,N/A,1976,https://openlibrary.org/works/OL3456752W
+The Valdez Marriage,Violet Winspear,N/A,1978,https://openlibrary.org/works/OL4440510W
+In Search of the Unknown,Robert W. Chambers,N/A,1904,https://openlibrary.org/works/OL8127245W
+The Ragamuffin Gospel,Brennan Manning,N/A,1990,https://openlibrary.org/works/OL2422261W
+The will to change,"bell hooks, Javier Saez, Marta Pera Cucurell",N/A,2004,https://openlibrary.org/works/OL31119W
+The monk who sold his Ferrari,Robin S. Sharma,N/A,1996,https://openlibrary.org/works/OL1854817W
+The 5 a.m. Club,"Robin S. Sharma, Robin Sharma",N/A,2018,https://openlibrary.org/works/OL19665926W
+The law on obligations and contracts,Hector S. de Leon,N/A,1969,https://openlibrary.org/works/OL1034024W
+The silence of the sea =,Vercors,N/A,1944,https://openlibrary.org/works/OL1198310W
+The Party,Christopher Pike,N/A,1988,https://openlibrary.org/works/OL1000809W
+We Hunt the Flame,Hafsah Faizal,N/A,2019,https://openlibrary.org/works/OL20083482W
+She Gets the Girl,"Rachael Lippincott, Alyson Derrick",N/A,2022,https://openlibrary.org/works/OL25345449W
+The Next Chapter,Jeff Kinney,N/A,2017,https://openlibrary.org/works/OL19714134W
+The Sense of an Ending,Julian Barnes,N/A,2011,https://openlibrary.org/works/OL15991772W
+Stellarlune,Shannon Messenger,N/A,2022,https://openlibrary.org/works/OL26348345W
+The autocrat of the breakfast-table,"Oliver Wendell Holmes, Sr.",N/A,1858,https://openlibrary.org/works/OL1109052W
+Made in America,Bill Bryson,N/A,1994,https://openlibrary.org/works/OL74122W
+Democracy and Education,John Dewey,N/A,1916,https://openlibrary.org/works/OL111359W
+The Summer I Turned Pretty Trilogy,Jenny Han,N/A,2009,https://openlibrary.org/works/OL17508740W
+The Custom of the Country,Edith Wharton,N/A,1900,https://openlibrary.org/works/OL98585W
+The discovery of the unconscious,Henri F. Ellenberger,N/A,1970,https://openlibrary.org/works/OL4319347W
+Ishmael,Daniel Quinn,N/A,1992,https://openlibrary.org/works/OL61787W
+Confessions of an advertising man,"Ogilvy, David",N/A,1963,https://openlibrary.org/works/OL3346507W
+The little book of common sense investing,John C. Bogle,N/A,2007,https://openlibrary.org/works/OL19728229W
+The Magic of the Lost Temple,Sudha Murty,N/A,2015,https://openlibrary.org/works/OL20121596W
+Island of the Dawn,Penny Jordan,N/A,1982,https://openlibrary.org/works/OL11327991W
+The Inmate,Freida McFadden,N/A,2022,https://openlibrary.org/works/OL31191485W
+The golden road,"Lucy Maud Montgomery, Ian Montgomery",N/A,1910,https://openlibrary.org/works/OL77780W
+Iron Flame - The Empyrean #2,Rebecca Yarros,N/A,2023,https://openlibrary.org/works/OL34028551W
+When rabbit howls,Truddi Chase,N/A,1987,https://openlibrary.org/works/OL15845911W
+The Art of Deception,"Kevin D. Mitnick, William L. Simon",N/A,2001,https://openlibrary.org/works/OL15188875W
+The Last Chronicle of Barset,Anthony Trollope,N/A,1867,https://openlibrary.org/works/OL109876W
+The Pied Piper of Hamelin,"Robert Browning, Ladybird Books Staff, Kate Greenaway",N/A,1888,https://openlibrary.org/works/OL284393W
+Empire of the summer moon,"S. C. Gwynne, S. C. Gwynne",N/A,2010,https://openlibrary.org/works/OL15233916W
+The way to rainy mountain,N. Scott Momaday,N/A,1969,https://openlibrary.org/works/OL25928W
+Ayurveda,Vasant Lad,N/A,1984,https://openlibrary.org/works/OL2695110W
+How to Build a Car,Adrian Newey,N/A,2017,https://openlibrary.org/works/OL20657752W
+Fear Street - The Thrill Club,Robert Lawrence Stine,N/A,1994,https://openlibrary.org/works/OL72402W
+"The Private Memoirs and Confessions of A Justified Sinner (With A Detail of Curious Traditionary Facts, And Other Evidence, By The Editor)","James Hogg, Ian Rankin, Wain, John.",N/A,1824,https://openlibrary.org/works/OL240077W
+Il diario segreto di Colette,Elisabetta Dami,N/A,2000,https://openlibrary.org/works/OL16813093W
+The Last Man Who Knew Everything,Andrew Robinson,N/A,2005,https://openlibrary.org/works/OL2990495W
+The library at Mount Char,"Scott Hawkins, Hillary Huber",N/A,2015,https://openlibrary.org/works/OL17836918W
+The Chinese parrot,Earl Derr Biggers,N/A,1926,https://openlibrary.org/works/OL6438825W
+Icebreaker,Hannah Grace,N/A,2020,https://openlibrary.org/works/OL28952677W
+Sociology,Anthony Giddens,N/A,1982,https://openlibrary.org/works/OL38123W
+The fine art of small talk,Debra Fine,N/A,1960,https://openlibrary.org/works/OL5964679W
+The Comfort Book,Matt Haig,N/A,2021,https://openlibrary.org/works/OL24653038W
+Tattoo Coloring Book for Adults,Jenny Olsen,N/A,2020,https://openlibrary.org/works/OL30585691W
+the sun and her flowers,Rupi Kaur,N/A,2017,https://openlibrary.org/works/OL17800586W
+Why does he do that?,Lundy Bancroft,N/A,2002,https://openlibrary.org/works/OL8076167W
+Works (Buried Talents / Dance of the Dead / Dress of White Silk / From Shadowed Places / I Am Legend / Mad House / Person to Person / Prey / The Funeral / The Near Departed / Witch War),Richard Matheson,N/A,1970,https://openlibrary.org/works/OL64225W
+The Gifts of Imperfection,Brené Brown,N/A,2010,https://openlibrary.org/works/OL16010306W
+All the lovely bad ones,Mary Downing Hahn,N/A,2008,https://openlibrary.org/works/OL60173W
+The Girl Next Door,Jack Ketchum,N/A,1989,https://openlibrary.org/works/OL8108989W
+The Trophy Husband,Lynne Graham,N/A,1996,https://openlibrary.org/works/OL7990778W
+Stalking Jack the Ripper,Kerri Maniscalco,N/A,2016,https://openlibrary.org/works/OL20039486W
+The curious garden,Peter Brown,N/A,2009,https://openlibrary.org/works/OL5705888W
+The Three Little Wolves and the Big Bad Pig,Eugenios Trivizas,N/A,1993,https://openlibrary.org/works/OL8316888W
+Dinotopia,James Gurney,N/A,1992,https://openlibrary.org/works/OL58400W
+The Threat of Love,Charlotte Lamb,N/A,1990,https://openlibrary.org/works/OL3294448W
+Green days by the river,"Anthony, Michael",N/A,1967,https://openlibrary.org/works/OL1728369W
+The explosive child,Ross W. Greene,N/A,1998,https://openlibrary.org/works/OL1901325W
+Endless Nights,Neil Gaiman,N/A,2003,https://openlibrary.org/works/OL679303W
+The Covenant of Water,Abraham Verghese,N/A,2023,https://openlibrary.org/works/OL29192912W
+The obstacle is the way,Ryan Holiday,N/A,2014,https://openlibrary.org/works/OL19977665W
+Ultralearning,"Scott Young, James Clear",N/A,2019,https://openlibrary.org/works/OL20846121W
+The radium girls,Kate Moore,N/A,2016,https://openlibrary.org/works/OL19663676W
+The masks of God,Joseph Campbell,N/A,1959,https://openlibrary.org/works/OL2497176W
+Pandora's Star,Peter F. Hamilton,N/A,2004,https://openlibrary.org/works/OL474061W
+Eagle Strike,Anthony Horowitz,N/A,2003,https://openlibrary.org/works/OL84767W
+Annie on My Mind,Nancy Garden,N/A,1982,https://openlibrary.org/works/OL505010W
+How the Garcia Girls Lost Their Accents,Julia Alvarez,N/A,1992,https://openlibrary.org/works/OL116088W
+Diary of an Oxygen Thief,Anonymous,N/A,2006,https://openlibrary.org/works/OL15728986W
+I Funny,"James Patterson, Chris Grabenstein",N/A,1900,https://openlibrary.org/works/OL17063362W
+Nonsense novels,"Stephen Leacock, Stephen Leacock, . Stephen",N/A,1900,https://openlibrary.org/works/OL626369W
+The Lonely Crowd,"David Riesman, Reuel Denney, Nathan Glazer",N/A,1950,https://openlibrary.org/works/OL15410871W
+The Sorcerer of the North,John Flanagan,N/A,2008,https://openlibrary.org/works/OL15166256W
+Genghis Khan and the Making of the Modern World,Jack Weatherford,N/A,2004,https://openlibrary.org/works/OL8162628W
+The Adventure of the Christmas Pudding,Agatha Christie,N/A,1960,https://openlibrary.org/works/OL472416W
+The wild man of the West,Robert Michael Ballantyne,N/A,1800,https://openlibrary.org/works/OL2320086W
+The Young Buglers,G. A. Henty,N/A,1880,https://openlibrary.org/works/OL1794677W
+"The Roman history, from the foundation of the City of Rome, to the destruction of the Western Empire",Oliver Goldsmith,N/A,1769,https://openlibrary.org/works/OL33282861W
+The World of Ice & Fire,"George R. R. Martin, Elio Garcia, Linda Antonsson",N/A,2014,https://openlibrary.org/works/OL17463087W
+The Do-Over,Lynn Painter,N/A,2022,https://openlibrary.org/works/OL27294011W
+Ain't I a Woman,"bell hooks, consonni, Gemma Deza Guil, Lorna Simpson",N/A,1981,https://openlibrary.org/works/OL31123W
+The Norton Anthology of World Literature,"Martin Puchner, Suzanne Conklin Akbari, Wiebke Denecke, Barbara Fuchs, Caroline Levine, Pericles Lewis, Emily Wilson",N/A,2012,https://openlibrary.org/works/OL20776250W
+The Adventures of Huckleberry Finn,Mark Twain,N/A,1960,https://openlibrary.org/works/OL37513138W
+The rough-face girl,Rafe Martin,N/A,1992,https://openlibrary.org/works/OL1810158W
+Histoire de Charles XII,Voltaire,N/A,1731,https://openlibrary.org/works/OL100671W
+Social Engineering,Christopher Hadnagy,N/A,2011,https://openlibrary.org/works/OL16495169W
+"Green River, Running Red",Ann Rule,N/A,2004,https://openlibrary.org/works/OL892134W
+The Satanic Bible,Anton Szandor LaVey,N/A,1969,https://openlibrary.org/works/OL697880W
+Common Stock Certificates Corporate Starter Kit,Platinum Black Services LLC,N/A,2018,https://openlibrary.org/works/OL20537907W
+Not Once But Twice,Betty Neels,N/A,1981,https://openlibrary.org/works/OL3457830W
+India after Gandhi,Ramachandra Guha,N/A,2007,https://openlibrary.org/works/OL15858520W
+Safe harbour,Danielle Steel,N/A,2003,https://openlibrary.org/works/OL19748W
+Dork Diaries,Rachel Renée Russell,N/A,2009,https://openlibrary.org/works/OL13655592W
+Railroad accident report,United States. National Transportation Safety Board.,N/A,1975,https://openlibrary.org/works/OL1739733W
+La mala hora,Gabriel García Márquez,N/A,1962,https://openlibrary.org/works/OL274539W
+JavaScript,"Douglas Crockford, Ke luo ke fu de, Yan xue kun, Douglas Crockford",N/A,2008,https://openlibrary.org/works/OL9486352W
+Aunt Jo's scrap-bag,Louisa May Alcott,N/A,1871,https://openlibrary.org/works/OL30067W
+Chicka chicka a b c,"Bill Martin Jr., John Archambault",N/A,1989,https://openlibrary.org/works/OL3387844W
+An Indigenous Peoples' History of the United States,Roxanne Dunbar Ortiz,N/A,2014,https://openlibrary.org/works/OL17640485W
+Honey and Spice,Bolu Babalola,N/A,2022,https://openlibrary.org/works/OL25347480W
+Stone Fox,John Reynolds Gardiner,N/A,1979,https://openlibrary.org/works/OL4316364W
+Childhood and society,Erik H. Erikson,N/A,1950,https://openlibrary.org/works/OL1194364W
+The Doctor's Dilemma,George Bernard Shaw,N/A,1911,https://openlibrary.org/works/OL1066522W
+One of us is next,Karen M. McManus,N/A,2020,https://openlibrary.org/works/OL20639427W
+Breath,"James Nestor, Arnau Figueras Deulofeu, Nelly Ganancia",N/A,2020,https://openlibrary.org/works/OL20799952W
+Soul of the Fire,Terry Goodkind,N/A,1999,https://openlibrary.org/works/OL2010448W
+The Midnight Club,Christopher Pike,N/A,1994,https://openlibrary.org/works/OL1000794W
+Alexander Hamilton,Ron Chernow,N/A,2004,https://openlibrary.org/works/OL2665176W
+Rules of Prey (Lucas Davenport Mysteries),John Sandford,N/A,1989,https://openlibrary.org/works/OL261504W
+The astrological tarot,Georges Muchery,N/A,1989,https://openlibrary.org/works/OL4851636W
+The Kissing Booth,Beth Reekles,N/A,2012,https://openlibrary.org/works/OL17576378W
+The Mister,E. L. James,N/A,2006,https://openlibrary.org/works/OL20121625W
+Materials science and engineering,William D. Callister,N/A,1985,https://openlibrary.org/works/OL3268935W
+The Marriage Possession,Helen Bianchin,N/A,2007,https://openlibrary.org/works/OL3498612W
+Overcoming overeating,"Jane R. Hirschmann, Carol H. Munter",N/A,1988,https://openlibrary.org/works/OL3497604W
+The Laws of Human Nature,Robert Greene,N/A,2018,https://openlibrary.org/works/OL19761410W
+The three hostages,John Buchan,N/A,1924,https://openlibrary.org/works/OL76591W
+When Nietzsche Wept,Irvin D. Yalom,N/A,1992,https://openlibrary.org/works/OL2680436W
+Bird by Bird,Anne Lamott,N/A,1994,https://openlibrary.org/works/OL489421W
+Bullshit Jobs,David Graeber,N/A,2018,https://openlibrary.org/works/OL20153626W
+U.S. Postal Service,United States. General Accounting Office,N/A,1987,https://openlibrary.org/works/OL565230W
+The Day of the Locust,Nathanael West,N/A,1939,https://openlibrary.org/works/OL3352321W
+Drums of Autumn,"Diana Gabaldon, Geraldine James",N/A,1997,https://openlibrary.org/works/OL3261150W
+The essential Calvin and Hobbes,Bill Watterson,N/A,1988,https://openlibrary.org/works/OL3004224W
+A Pair of Blue Eyes,Thomas Hardy,N/A,1800,https://openlibrary.org/works/OL44987W
+Whoever You Are,"Mem Fox, Leslie Staub",N/A,1997,https://openlibrary.org/works/OL650936W
+Convenience store woman,"村田沙耶香, Nancy Wu, Mathilde Tamae-Bouhon, Albert Nolla Cabellos, Marina Bornas Montaña",N/A,2018,https://openlibrary.org/works/OL19744024W
+Way of the Wolf : Straight Line Selling,Jordan Belfort,N/A,2017,https://openlibrary.org/works/OL20168722W
+Oceano mare,Alessandro Baricco,N/A,1993,https://openlibrary.org/works/OL876498W
+The War of Art,Steven Pressfield,N/A,2002,https://openlibrary.org/works/OL497483W
+Think Again,Adam Grant,N/A,2021,https://openlibrary.org/works/OL22484556W
+Boundaries,"Henry Cloud, John Sims Townsend, Henry O. Arnold",N/A,1992,https://openlibrary.org/works/OL15134775W
+The gentle art of verbal self-defense,Suzette Haden Elgin,N/A,1980,https://openlibrary.org/works/OL492348W
+"Elizabeth I, red rose of the House of Tudor","Kathryn Lasky, Josephine Bailey",N/A,1999,https://openlibrary.org/works/OL121818W
+Happily Ever After,Kiera Cass,N/A,2015,https://openlibrary.org/works/OL17356841W
+The bloody chamber and other stories,Angela Carter,N/A,1979,https://openlibrary.org/works/OL697426W
+A Curse for True Love,Stephanie Garber,N/A,2023,https://openlibrary.org/works/OL33364737W
+Coraline,"P. Craig Russell, Neil Gaiman",N/A,2008,https://openlibrary.org/works/OL13752343W
+Everything I never told you,Celeste Ng,N/A,2014,https://openlibrary.org/works/OL17295077W
+Wicca,Scott Cunningham,N/A,1988,https://openlibrary.org/works/OL80473W
+A Closed and Common Orbit,Becky Chambers,N/A,2016,https://openlibrary.org/works/OL17897265W
+The Masqueraders,Georgette Heyer,N/A,1928,https://openlibrary.org/works/OL16478203W
+Shadowfires,Dean Koontz,N/A,1987,https://openlibrary.org/works/OL257748W
+Science Leveled Readers,Houghton Mifflin Harcourt Staff,N/A,2011,https://openlibrary.org/works/OL27467378W
+The Demigod Diaries,Rick Riordan,N/A,2012,https://openlibrary.org/works/OL16282935W
+Nostradamus,Mario Reading,N/A,2006,https://openlibrary.org/works/OL8940191W
+The Last Colony,John Scalzi,N/A,2007,https://openlibrary.org/works/OL5734646W
+Hollow City,Ransom Riggs,N/A,2013,https://openlibrary.org/works/OL17352242W
+The Evil Shepherd,Edward Phillips Oppenheim,N/A,1922,https://openlibrary.org/works/OL2681032W
+Beasts and Super-Beasts,Saki,N/A,1914,https://openlibrary.org/works/OL29115502W
+What Katy Did Next (Best Loved Stories),"Susan Coolidge, Jessie Mcdermot",N/A,1886,https://openlibrary.org/works/OL5114588W
+Pictures from Italy,Charles Dickens,N/A,1846,https://openlibrary.org/works/OL14869503W
+The Secret Wife,Lynne Graham,N/A,1997,https://openlibrary.org/works/OL3773966W
+Love Letters to the Dead,Ava Dellaira,N/A,2013,https://openlibrary.org/works/OL20103989W
+Invitation to the game,Monica Hughes        ,N/A,1990,https://openlibrary.org/works/OL574843W
+Echoes of the Past,Sally Wentworth,N/A,1989,https://openlibrary.org/works/OL3770492W
+Louis the Fish,"Arthur Yorinks, Richard Egielski",N/A,1980,https://openlibrary.org/works/OL483229W
+Oliver Goldsmith,Washington Irving,N/A,1840,https://openlibrary.org/works/OL63979W
+Happy Place,Emily Henry,N/A,2023,https://openlibrary.org/works/OL28607665W
+The Big Bow Mystery,Israel Zangwill,N/A,1892,https://openlibrary.org/works/OL1285628W
+At the Waterworks,Joanna Cole,N/A,1986,https://openlibrary.org/works/OL83091W
+Love Theoretically,Ali Hazelwood,N/A,2023,https://openlibrary.org/works/OL28803485W
+Lost Continent,Tui T. Sutherland,N/A,2018,https://openlibrary.org/works/OL21362955W
+Down the rabbit hole,Holly Madison,N/A,2015,https://openlibrary.org/works/OL20006577W
+Does the center hold?,Donald Palmer,N/A,1991,https://openlibrary.org/works/OL3162158W
+Darker,E. L. James,N/A,2017,https://openlibrary.org/works/OL17897191W
+Government by the people,"James MacGregor Burns, Thomas E. Cronin, David B. Magleby, J. W. Peltason, Tom Cronin, David O'Brien, Paul Charles Light, James Burns, James MacGregor, David M. O'Brien",N/A,1952,https://openlibrary.org/works/OL30492W
+The lion and the jewel,Wole Soyinka,N/A,1962,https://openlibrary.org/works/OL15125380W
+More happy than not,Adam Silvera,N/A,2015,https://openlibrary.org/works/OL20004466W
+Crush it!,Gary Vaynerchuk,N/A,2009,https://openlibrary.org/works/OL15110999W
+Anne of Green Gables,Lucy Maud Montgomery,N/A,1908,https://openlibrary.org/works/OL40955314W
+Poor Economics,"Abhijit Banerjee, Esther Duflo",N/A,2011,https://openlibrary.org/works/OL15743097W
+Il Fate del Lago,Elisabetta Dami,N/A,2012,https://openlibrary.org/works/OL19969194W
+The culture code,Daniel Coyle,N/A,2018,https://openlibrary.org/works/OL19670476W
+Boy of the pyramids,Ruth Fosdick Jones,N/A,1952,https://openlibrary.org/works/OL7465542W
+"I Survived The Nazi Invasion, 1944","Lauren Tarshis, Georgia Ball, Álvaro Sarraseca",N/A,2014,https://openlibrary.org/works/OL17104602W
+The Fear Street Saga - The Secret,Robert Lawrence Stine,N/A,1993,https://openlibrary.org/works/OL72397W
+Can't Hurt Me,David Goggins,N/A,2018,https://openlibrary.org/works/OL18108064W
+Love Insurance,Earl Derr Biggers,N/A,1914,https://openlibrary.org/works/OL6438822W
+Across the Wide and Lonesome Prairie,Kristiana Gregory,N/A,1997,https://openlibrary.org/works/OL121808W
+In the Days of Drake,Joseph Smith Fletcher,N/A,1895,https://openlibrary.org/works/OL1797739W
+Outwitting the devil,Napoleon Hill,N/A,2011,https://openlibrary.org/works/OL16176999W
+Star Wars - Dawn of the Jedi - Into the Void,Tim Lebbon,N/A,2001,https://openlibrary.org/works/OL16802620W
+Sisterhood is Powerful,Robin Morgan,N/A,1970,https://openlibrary.org/works/OL19003W
+Art of Public Speaking,Dale Carnegie,N/A,2011,https://openlibrary.org/works/OL26671797W
+Frames of mind,Howard Gardner,N/A,1983,https://openlibrary.org/works/OL116391W
+The Adventure of the Bruce-Partington Plans,Arthur Conan Doyle,N/A,1908,https://openlibrary.org/works/OL262416W
+Misbehaving,Richard H. Thaler,N/A,2015,https://openlibrary.org/works/OL17940527W
+Carrie Soto Is Back,"Taylor Jenkins Reid, María del Carme Boy Ruiz",N/A,2022,https://openlibrary.org/works/OL27305925W
+One Night at the Call Center,Chetan Bhagat,N/A,2005,https://openlibrary.org/works/OL5762087W
+Oh Money Money,Eleanor Hodgman Porter,N/A,1918,https://openlibrary.org/works/OL2775770W
+The Man Who Knew Infinity,Robert Kanigel,N/A,1991,https://openlibrary.org/works/OL3333455W
+Backwoods of Canada,"Catherine Parr Traill, Michael A. Peterman",N/A,1836,https://openlibrary.org/works/OL2802649W
+The Iron Man,"Kay Thorpe, Kay Thorpe",N/A,1974,https://openlibrary.org/works/OL3759468W
+The Deal,Elle Kennedy,N/A,2015,https://openlibrary.org/works/OL20878440W
+Il Fate del Nevi,Elisabetta Dami,N/A,2013,https://openlibrary.org/works/OL17081843W
+The Righteous Mind,"Jonathan Haidt, Antonio Kuntz",N/A,2012,https://openlibrary.org/works/OL16568840W
+"An alarm to unconverted sinners, in a serious treatise",Joseph Alleine,N/A,1672,https://openlibrary.org/works/OL6956024W
+Müdigkeitsgesellschaft,Byung-Chul Han,N/A,2010,https://openlibrary.org/works/OL17795654W
+The Secrets of Sir Richard Kenworthy,Julia Quinn,N/A,2014,https://openlibrary.org/works/OL18820936W
+People of the lie,M. Scott Peck,N/A,1983,https://openlibrary.org/works/OL2868907W
+The Perfect Marriage,Jeneva Rose,N/A,2020,https://openlibrary.org/works/OL24315820W
+The pig that wants to be eaten,Julian Baggini,N/A,2005,https://openlibrary.org/works/OL5745559W
+The Housemaid Is Watching,Freida McFadden,N/A,2024,https://openlibrary.org/works/OL37576476W
+The Calvin and Hobbes tenth anniversary book,Bill Watterson,N/A,1989,https://openlibrary.org/works/OL3004168W
+To Say Nothing of the Dog,Connie Willis,N/A,1997,https://openlibrary.org/works/OL14858392W
+Mission flamenco,"Elisabetta Dami, Helena Aguilà",N/A,2012,https://openlibrary.org/works/OL16813569W
+Figure Drawing for All It's Worth,Andrew Loomis,N/A,1943,https://openlibrary.org/works/OL181332W
+New Fear Street - The Stepbrother,Robert Lawrence Stine,N/A,1998,https://openlibrary.org/works/OL9964745W
+Just for the Summer,Abby Jimenez,N/A,2024,https://openlibrary.org/works/OL37575309W
+Human Compatible,Stuart J. Russell,N/A,2019,https://openlibrary.org/works/OL20492448W
+Unmasking Autism,Devon Price,N/A,2022,https://openlibrary.org/works/OL25325902W
+Zen in the art of writing,Ray Bradbury,N/A,1990,https://openlibrary.org/works/OL103150W
+Portrait of the Artist As a Young Man,James Joyce,N/A,2016,https://openlibrary.org/works/OL29583061W
+Stamped,"Jason Reynolds, Ibram X. Kendi",N/A,2020,https://openlibrary.org/works/OL20652384W
+The Black Echo (Harry Bosch),Michael Connelly,N/A,1992,https://openlibrary.org/works/OL111748W
+My life with the Walter boys,Ali Novak,N/A,2014,https://openlibrary.org/works/OL19989443W
+Batman,"Frank Miller, David Mazzucchelli",N/A,1986,https://openlibrary.org/works/OL253475W
+The charisma myth,"Olivia Fox Cabane, Olivia Cabane, Lisa Cordileone",N/A,2012,https://openlibrary.org/works/OL16240171W
+Journal du voleur,Jean Genet,N/A,1949,https://openlibrary.org/works/OL1281888W
+Beach Read,"Emily Henry, Anna Valor Blanquer",N/A,2020,https://openlibrary.org/works/OL20734329W
+Thanksgiving on Thursday,"Mary Pope Osborne, Sal Murdocca",N/A,2002,https://openlibrary.org/works/OL81813W
+"Anne of Geierstein, or, The maiden of the mist",Sir Walter Scott,N/A,1800,https://openlibrary.org/works/OL863772W
+The Postman,David Brin,N/A,1985,https://openlibrary.org/works/OL58708W
+Awaken the Giant Within,Tony Robbins,N/A,1991,https://openlibrary.org/works/OL3749279W
+Religio medici,Thomas Browne,N/A,1642,https://openlibrary.org/works/OL997527W
+Rules Of The Game,Penny Jordan,N/A,1984,https://openlibrary.org/works/OL11327968W
+The Bastard of Istanbul,Elif Şafak,N/A,2006,https://openlibrary.org/works/OL1021391W
+The Shadows Between Us,"Tricia Levenseller, Caitlin Davies",N/A,2020,https://openlibrary.org/works/OL20814542W
+Make Your Bed,"William H. McRaven, William H. McRaven, Make Your Make Your Bed",N/A,2017,https://openlibrary.org/works/OL17710052W
+The distance between us,Reyna Grande,N/A,2013,https://openlibrary.org/works/OL20037189W
+In the Realm of Hungry Ghosts,Gabor Maté,N/A,2008,https://openlibrary.org/works/OL8036789W
+The velvet rage,Alan Downs,N/A,2005,https://openlibrary.org/works/OL1901732W
+Tatto Coloring Book for Adult,Dream Tattos,N/A,2020,https://openlibrary.org/works/OL30941617W
+Tales of Greek Heroes,"Roger Lancelyn Green, Betty Middleton-Sandford",N/A,1958,https://openlibrary.org/works/OL3461880W
+The Boy at the Top of the Mountain,John Boyne,N/A,2015,https://openlibrary.org/works/OL17323728W
+Avatar,"Michael Dante DiMartino, Bryan Kanietzko",N/A,2006,https://openlibrary.org/works/OL15416051W
+Clean Code,Robert C. Martin,N/A,2008,https://openlibrary.org/works/OL17618370W
+House of Leaves,Mark Z. Danielewski,N/A,1998,https://openlibrary.org/works/OL32195W
+Destructive emotions,Daniel Goleman,N/A,2003,https://openlibrary.org/works/OL1878300W
+Back to the Batcave,"Adam West, Jeff Rovin",N/A,1994,https://openlibrary.org/works/OL3684889W
+The Last House on Needless Street,Catriona Ward,N/A,2021,https://openlibrary.org/works/OL24312716W
+Malgudi days,Rasipuram Krishnaswamy Narayan,N/A,1982,https://openlibrary.org/works/OL1057177W
+Pretty Little Liars,Sara Shepard,N/A,2006,https://openlibrary.org/works/OL276728W
+The millionaire master plan,Roger James Hamilton,N/A,2014,https://openlibrary.org/works/OL19986251W
+"""And I was there""","Layton, Edwin T., Edwin T. Layton, Roger Pineau, John Costello",N/A,1985,https://openlibrary.org/works/OL5102602W
+The killing of the unicorn,Peter Bogdanovich,N/A,1984,https://openlibrary.org/works/OL452222W
+Crotchet Castle,Thomas Love Peacock,N/A,1831,https://openlibrary.org/works/OL2713463W
+Poor Charlie's Almanack,"Charles T. Munger, Charles T. Munger",N/A,2005,https://openlibrary.org/works/OL8928012W
+Una cascata di cioccolato,Elisabetta Dami,N/A,2013,https://openlibrary.org/works/OL17082485W
+We Are the Ants,Shaun David Hutchinson,N/A,2016,https://openlibrary.org/works/OL17934983W
+The Color of Law,Richard Rothstein,N/A,2017,https://openlibrary.org/works/OL19671595W
+Winnie the Pooh and the Blustery Day,"Walt Disney Company, A. A. Milne, Walt Disney Records",N/A,2002,https://openlibrary.org/works/OL8070614W
+Correspondence,Wolfgang Amadeus Mozart,N/A,1865,https://openlibrary.org/works/OL624288W
+Ghost story,Peter Straub,N/A,1979,https://openlibrary.org/works/OL114299W
+Albertine disparue,Marcel Proust,N/A,1900,https://openlibrary.org/works/OL23791139W
+The Isle of the Lost,Melissa De La Cruz,N/A,2015,https://openlibrary.org/works/OL19355372W
+David Balfour,Robert Louis Stevenson,N/A,1883,https://openlibrary.org/works/OL24163W
+The Skin I'm In,Sharon G. Flake,N/A,1999,https://openlibrary.org/works/OL478995W
+The Call of Cthulhu,H.P. Lovecraft,N/A,2016,https://openlibrary.org/works/OL20804234W
+The now habit,Neil Fiore,N/A,1988,https://openlibrary.org/works/OL4439701W
+The Intelligence Trap,David Robson,N/A,2019,https://openlibrary.org/works/OL21363057W
+Love & Respect,Emerson Eggerichs,N/A,2004,https://openlibrary.org/works/OL8966593W
+Fear Street - The Face,Robert Lawrence Stine,N/A,1996,https://openlibrary.org/works/OL9964694W
+The Secret Language of Relationships,Gary Goldschneider,N/A,1997,https://openlibrary.org/works/OL14985961W
+The Norton field guide to writing,Richard H. Bullock,N/A,2006,https://openlibrary.org/works/OL5847286W
+The Dark Side of Desire,Michelle Reid,N/A,1991,https://openlibrary.org/works/OL4233175W
+"Be Water, My Friend",Shannon Lee,N/A,2020,https://openlibrary.org/works/OL21686956W
+A paixão segundo G.H.,Clarice Lispector,N/A,1964,https://openlibrary.org/works/OL1002138W
+Fear Street saga,Robert Lawrence Stine,N/A,1996,https://openlibrary.org/works/OL17306484W
+The Flames of Hope,Tui T. Sutherland,N/A,2022,https://openlibrary.org/works/OL24738819W
+The Light We Carry,Michelle Obama,N/A,2022,https://openlibrary.org/works/OL28557478W
+Keepers of the Garden,Dolores Cannon,N/A,1993,https://openlibrary.org/works/OL544209W
+On a pale horse,Piers Anthony,N/A,1983,https://openlibrary.org/works/OL80857W
+Married to a Mistress,Lynne Graham,N/A,1998,https://openlibrary.org/works/OL3773994W
+Unlocked,Shannon Messenger,N/A,2020,https://openlibrary.org/works/OL21902613W
+Compensation,"George T. Milkovich, Jerry M Newman, Carolyn Milkovich",N/A,1984,https://openlibrary.org/works/OL1900985W
+Guide to quality control,Kaoru Ishikawa,N/A,1972,https://openlibrary.org/works/OL120949W
+"An English translation of Parsifal, the sacred festival drama by Richard Wagner","Richard Wagner, Rosemarie König, Kurt Pahlen, John P. Jackson, Benjamin Johnson Lang, Alfred Forman, Oliver Huckel, Karl Klindworth, Louis Napoleon Parker, Randle Fynes",N/A,1879,https://openlibrary.org/works/OL579103W
+Under the feet of Jesus,Helena María Viramontes,N/A,1995,https://openlibrary.org/works/OL3086852W
+True to the Game II,Teri Woods,N/A,2007,https://openlibrary.org/works/OL8135772W
+No Rules Rules,"Reed Hastings, Erin Meyer",N/A,2020,https://openlibrary.org/works/OL21674578W
+Prescription for nutritional healing,"James F. Balch, Phyllis A. Balch, Stacey J. Bell",N/A,1990,https://openlibrary.org/works/OL551319W
+The Locked Door,Freida McFadden,N/A,2021,https://openlibrary.org/works/OL28954802W
+The History of Love,Nicole Krauss,N/A,2005,https://openlibrary.org/works/OL5814543W
+The Ringworld Engineers (Ringworld),Larry Niven,N/A,1979,https://openlibrary.org/works/OL510404W
+The Italian Billionaire's Pregnant Bride,Lynne Graham,N/A,2008,https://openlibrary.org/works/OL3773929W
+The Silkworm,J. K. Rowling,N/A,2014,https://openlibrary.org/works/OL17324632W
+The Fury and Dark Reunion,Lisa Jane Smith,N/A,2007,https://openlibrary.org/works/OL4444212W
+The Lone Drow,R. A. Salvatore,N/A,2003,https://openlibrary.org/works/OL516736W
+I segreti dell'Olimpo,Elisabetta Dami,N/A,2005,https://openlibrary.org/works/OL19988954W
+Thea Stilton and the Cherry Blossom Adventure (Thea Stilton 6),Elisabetta Dami,N/A,2010,https://openlibrary.org/works/OL15678484W
+Riding Freedom,"Pam Muñoz Ryan, Nuria Molinero, Philippe Poirier, Hélène Georges, Dominique Delord, Brian Selznick",N/A,1998,https://openlibrary.org/works/OL784060W
+Edgedancer,Brandon Sanderson,N/A,2016,https://openlibrary.org/works/OL19631308W
+This is How You Lose the Time War,"Amal El-Mohtar, Max Gladstone",N/A,2019,https://openlibrary.org/works/OL19859295W
+The beautyful ones are not yet born,Ayi Kwei Armah,N/A,1968,https://openlibrary.org/works/OL2334845W
+Bitten,"Kelley Armstrong, Aasne Vigesaa",N/A,2001,https://openlibrary.org/works/OL5810959W
+The Bone Clocks,"David Mitchell, David Mitchell",N/A,2014,https://openlibrary.org/works/OL17078738W
+Trump,"Tony Schwartz, Donald Trump",N/A,1987,https://openlibrary.org/works/OL15026140W
+The Mummy,Anne Rice,N/A,1989,https://openlibrary.org/works/OL77835W
+The Aspern Papers,"Henry James, Robin Field",N/A,1890,https://openlibrary.org/works/OL276315W
+The Kite Runner--the graphic novel,Khaled Hosseini,N/A,2011,https://openlibrary.org/works/OL15902631W
+Fear Street - The Stepsister 2,Robert Lawrence Stine,N/A,1995,https://openlibrary.org/works/OL72338W
+Legends & Lattes,Travis Baldree,N/A,2022,https://openlibrary.org/works/OL27591348W
+How to be rich,"J. Paul Getty, J. Paul Getty",N/A,1965,https://openlibrary.org/works/OL3408913W
+Toxic Parents,Susan Forward,N/A,1988,https://openlibrary.org/works/OL1929420W
+Skippyjon Jones,Judith Byron Schachner,N/A,2003,https://openlibrary.org/works/OL1839039W
+Strategic market management,David A. Aaker,N/A,1984,https://openlibrary.org/works/OL1839162W
+"The Unbecoming of Mara Dyer (Mara Dyer Series, Book 1)",Michelle Hodkin,N/A,2011,https://openlibrary.org/works/OL16358742W
+The Mythical Man-Month,Frederick P. Brooks,N/A,1975,https://openlibrary.org/works/OL3510570W
+A Garland for Girls,Louisa May Alcott,N/A,1887,https://openlibrary.org/works/OL15188919W
+The Enormous Potato,Aubrey Davis,N/A,1997,https://openlibrary.org/works/OL8117439W
+The longest memory,Fred D'Aguiar,N/A,1994,https://openlibrary.org/works/OL15855900W
+The Other Woman,Jessica Steele,N/A,1980,https://openlibrary.org/works/OL3845148W
+The Forced Bride,Sara Craven,N/A,2006,https://openlibrary.org/works/OL3467511W
+The Impossible Woman,Emma Darcy,N/A,1985,https://openlibrary.org/works/OL2959243W
+Striker,Ana Huang,N/A,2024,https://openlibrary.org/works/OL37830129W
+The Wrath & the Dawn,Renée Ahdieh,N/A,1700,https://openlibrary.org/works/OL17613127W
+Dibs in Search of Self,Virginia M. Axline,N/A,1964,https://openlibrary.org/works/OL7971357W
+The Wolf of Wall Street,Jordan Belfort,N/A,2007,https://openlibrary.org/works/OL8383186W
+Murder in the Family,Cara Hunter,N/A,2023,https://openlibrary.org/works/OL27815472W
+The Icebound Land,John Flanagan,N/A,2007,https://openlibrary.org/works/OL5721971W
+The iron trial,"Holly Black, Cassandra Clare",N/A,2014,https://openlibrary.org/works/OL17062645W
+Fear Street - Into The Dark,Robert Lawrence Stine,N/A,1997,https://openlibrary.org/works/OL15094406W
+Tell the wolves I'm home,Carol Rifka Brunt,N/A,2012,https://openlibrary.org/works/OL16686856W
+Encounter,Jane Yolen,N/A,1989,https://openlibrary.org/works/OL97354W
+Billionaire Boy,"David Walliams, Ricard Gil Giner;",N/A,2010,https://openlibrary.org/works/OL21027778W
+Hell's Angels,Hunter S. Thompson,N/A,1966,https://openlibrary.org/works/OL158104W
+"Whitney, My Love",Judith McNaught,N/A,1985,https://openlibrary.org/works/OL152332W
+Pyongyang,Guy Delisle,N/A,2003,https://openlibrary.org/works/OL16026699W
+The 3 Mistakes of My Life,Chetan Bhagat,N/A,1990,https://openlibrary.org/works/OL5762086W


### PR DESCRIPTION
This PR adds a new scraper to fetch books from OpenLibrary
Fields collected: Title, Author, Subjects, PublishYear, Link.  

Output is saved as openlibrary_books.csv in output folder  

Fully robots.txt compliant and uses polite crawl delays.  
