### PR TITLE
Add output manager and CLI format option

### DIFF
--- a/1. flipkart.py
+++ b/1. flipkart.py
@@ -1,8 +1,9 @@
 import requests
 from bs4 import BeautifulSoup
-import csv
 import time
 import os
+import argparse
+from output_manager import OutputManager
 
 BASE_URL = 'https://www.flipkart.com/search?q=smartphones'
 
@@ -56,19 +57,13 @@ for page in range(1, 42):
             
     time.sleep(1)
 
-if products:
-    fieldnames = ['Name', 'Price', 'Rating', 'Description']
-    
-    output_dir = 'output'
-    csv_path = os.path.join(output_dir, 'flipkart_latest_smartphone.csv')
-    
-    os.makedirs(output_dir, exist_ok=True) 
-    
-    with open(csv_path, 'w', encoding="utf-8", newline='') as csvfile:
-        writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
-        writer.writeheader()
-        writer.writerows(products)
-        
-    print(f"\nSuccessfully saved {len(products)} products to {csv_path}")
-else:
-    print("\nNo products were scraped. The selectors may need updating again.")
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Scrape Flipkart for smartphone data.')
+    parser.add_argument('--format', type=str, default='csv', help='Output format: csv, json, or xml')
+    args = parser.parse_args()
+
+    if products:
+        output_manager = OutputManager()
+        output_manager.save(products, 'flipkart_latest_smartphone', args.format)
+    else:
+        print("\nNo products were scraped. The selectors may need updating again.")

--- a/gitignore.txt
+++ b/gitignore.txt
@@ -1,0 +1,7 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Output files
+output/

--- a/output_manager.py
+++ b/output_manager.py
@@ -1,0 +1,59 @@
+import csv
+import json
+import xml.etree.ElementTree as ET
+from xml.dom.minidom import parseString
+import os
+
+class OutputManager:
+    def __init__(self, output_dir='output'):
+        self.output_dir = output_dir
+        os.makedirs(self.output_dir, exist_ok=True)
+
+    def save_to_csv(self, data, filename):
+        path = os.path.join(self.output_dir, filename)
+        with open(path, 'w', newline='', encoding='utf-8') as f:
+            if data:
+                writer = csv.DictWriter(f, fieldnames=data[0].keys())
+                writer.writeheader()
+                writer.writerows(data)
+        print(f"Data saved to {path}")
+
+    def save_to_json(self, data, filename):
+        path = os.path.join(self.output_dir, filename)
+        with open(path, 'w', encoding='utf-8') as f:
+            json.dump(data, f, indent=4)
+        print(f"Data saved to {path}")
+
+    def save_to_xml(self, data, filename):
+        root = ET.Element("items")
+        for item in data:
+            item_elem = ET.SubElement(root, "item")
+            for key, val in item.items():
+                child = ET.SubElement(item_elem, key.replace(" ", "_"))
+                child.text = str(val)
+        
+        # Pretty print
+        xml_str = ET.tostring(root, 'utf-8')
+        dom = parseString(xml_str)
+        pretty_xml_str = dom.toprettyxml(indent="  ")
+
+        path = os.path.join(self.output_dir, filename)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(pretty_xml_str)
+        print(f"Data saved to {path}")
+
+    def save(self, data, filename_base, format='csv'):
+        if not data:
+            print("No data to save.")
+            return
+
+        format = format.lower()
+        if format == 'csv':
+            self.save_to_csv(data, f"{filename_base}.csv")
+        elif format == 'json':
+            self.save_to_json(data, f"{filename_base}.json")
+        elif format == 'xml':
+            self.save_to_xml(data, f"{filename_base}.xml")
+        else:
+            print(f"Unsupported format: {format}")
+


### PR DESCRIPTION
Refactored Flipkart scraper to use an OutputManager class for saving data in CSV, JSON, or XML formats. Added argparse support for specifying output format via command line. Also added a .gitignore file to exclude output and Python cache files.